### PR TITLE
Fix non-HTTPException error handling

### DIFF
--- a/profiles/factory.py
+++ b/profiles/factory.py
@@ -4,7 +4,7 @@ from flask import Flask, jsonify, make_response, redirect, request
 from profiles.api.errors import OAuth2Error, ClientError
 from profiles.api.oauth2 import OAUTH2_BP
 from profiles.api.ping import PING_BP
-from profiles.utilities import remove_none_values
+from profiles.utilities import remove_none_values, chain_exception
 from werkzeug.exceptions import HTTPException, InternalServerError
 from werkzeug.wrappers import Response
 
@@ -17,7 +17,7 @@ def create_app(config: dict) -> Flask:
     app.register_blueprint(OAUTH2_BP, url_prefix='/oauth2')
     app.register_blueprint(PING_BP)
 
-    def http_error_handler(exception: Exception) -> Response:
+    def error_handler(exception: Exception) -> Response:
         if isinstance(exception, ClientError):
             return redirect(exception.uri + '?' + urlencode(remove_none_values({
                 'error': exception.error,
@@ -32,7 +32,7 @@ def create_app(config: dict) -> Flask:
             return make_response(jsonify(body), exception.status_code)
 
         if not isinstance(exception, HTTPException):
-            exception = InternalServerError(str(exception))
+            exception = chain_exception(InternalServerError, exception)
 
         if request.path.startswith('/oauth2/authorize') or request.path.startswith('/oauth2/check'):
             return make_response(exception, exception.code)
@@ -47,6 +47,8 @@ def create_app(config: dict) -> Flask:
 
     from werkzeug.exceptions import default_exceptions
     for code in default_exceptions:
-        app.errorhandler(code)(http_error_handler)
+        app.errorhandler(code)(error_handler)
+
+    app.register_error_handler(Exception, error_handler)
 
     return app

--- a/profiles/factory.py
+++ b/profiles/factory.py
@@ -4,7 +4,7 @@ from flask import Flask, jsonify, make_response, redirect, request
 from profiles.api.errors import OAuth2Error, ClientError
 from profiles.api.oauth2 import OAUTH2_BP
 from profiles.api.ping import PING_BP
-from profiles.utilities import remove_none_values, chain_exception
+from profiles.utilities import chain_exception, remove_none_values
 from werkzeug.exceptions import HTTPException, InternalServerError
 from werkzeug.wrappers import Response
 

--- a/profiles/utilities.py
+++ b/profiles/utilities.py
@@ -1,2 +1,11 @@
+from typing import Type
+
+
+def chain_exception(exception: Type[Exception], previous: Exception, message: str = None):
+    exception = exception(message or str(previous))
+    exception.__cause__ = previous
+    return exception
+
+
 def remove_none_values(items: dict) -> dict:
     return dict(filter(lambda item: item[1] is not None, items.items()))


### PR DESCRIPTION
Not sure how PyCharm is running pytest differently, but it was showing some non HTTPExceptions not being handled (but still as  passes; `project_tests.sh` just showed passes).