### PR TITLE
Allow additional, unused configuration

### DIFF
--- a/profiles/config.py
+++ b/profiles/config.py
@@ -9,7 +9,7 @@ class Config(ABC):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     TESTING = False
 
-    def __init__(self, orcid: Dict[str, str], db: str) -> None:
+    def __init__(self, orcid: Dict[str, str], db: str, **_kwargs) -> None:
         self.orcid = orcid
         self.SQLALCHEMY_DATABASE_URI = db  # pylint: disable=invalid-name
 


### PR DESCRIPTION
For forward compatibility, allow the formula to provide more configuration that needed (e.g. a `logging` key). This configuration is ignored.