### PR TITLE
Handle private names

### DIFF
--- a/migrations/versions/b619f44789e4_.py
+++ b/migrations/versions/b619f44789e4_.py
@@ -1,0 +1,49 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b619f44789e4'
+down_revision = '14f5651419ad'
+branch_labels = None
+depends_on = None
+
+profile_helper = sa.Table(
+    'profile',
+    sa.MetaData(),
+    sa.Column('id', sa.String(length=8), nullable=False),
+    sa.Column('preferred_name', sa.Text(), nullable=False),
+    sa.Column('index_name', sa.Text(), nullable=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    profiles = connection.execute(
+        profile_helper.select().where(profile_helper.c.preferred_name == ''))
+
+    for profile in profiles:
+        connection.execute(
+            profile_helper.update().where(
+                profile_helper.c.id == profile.id
+            ).values(
+                index_name='(Unknown)',
+                preferred_name='(Unknown)'
+            )
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    profiles = connection.execute(
+        profile_helper.select().where(profile_helper.c.preferred_name == '(Unknown)'))
+
+    for profile in profiles:
+        connection.execute(
+            profile_helper.update().where(
+                profile_helper.c.id == profile.id
+            ).values(
+                index_name='',
+                preferred_name=''
+            )
+        )

--- a/migrations/versions/b619f44789e4_.py
+++ b/migrations/versions/b619f44789e4_.py
@@ -9,41 +9,15 @@ depends_on = None
 profile_helper = sa.Table(
     'profile',
     sa.MetaData(),
-    sa.Column('id', sa.String(length=8), nullable=False),
     sa.Column('preferred_name', sa.Text(), nullable=False),
-    sa.Column('index_name', sa.Text(), nullable=True),
 )
 
 
 def upgrade():
     connection = op.get_bind()
 
-    profiles = connection.execute(
-        profile_helper.select().where(profile_helper.c.preferred_name == ''))
-
-    for profile in profiles:
-        connection.execute(
-            profile_helper.update().where(
-                profile_helper.c.id == profile.id
-            ).values(
-                index_name='(Unknown)',
-                preferred_name='(Unknown)'
-            )
-        )
+    connection.execute(profile_helper.delete().where(profile_helper.c.preferred_name == ''))
 
 
 def downgrade():
-    connection = op.get_bind()
-
-    profiles = connection.execute(
-        profile_helper.select().where(profile_helper.c.preferred_name == '(Unknown)'))
-
-    for profile in profiles:
-        connection.execute(
-            profile_helper.update().where(
-                profile_helper.c.id == profile.id
-            ).values(
-                index_name='',
-                preferred_name=''
-            )
-        )
+    pass

--- a/profiles/api/oauth2.py
+++ b/profiles/api/oauth2.py
@@ -127,10 +127,10 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
 
         try:
             profile = profiles.get_by_orcid(json_data['orcid'])
-            if json_data.get('name', ''):
+            if json_data['name']:
                 profile.name = Name(json_data['name'])
         except ProfileNotFound:
-            if not json_data.get('name', ''):
+            if not json_data['name']:
                 raise InvalidRequest('No name visible')
             profile = Profile(profiles.next_id(), Name(json_data['name']), json_data['orcid'])
             profiles.add(profile)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -8,7 +8,6 @@ from profiles.database import UTCDateTime, db
 from profiles.utilities import guess_index_name
 
 ID_LENGTH = 8
-UNKNOWN_NAME = '(Unknown)'
 
 
 class OrcidToken(db.Model):
@@ -27,9 +26,6 @@ class OrcidToken(db.Model):
 
 class Name(object):
     def __init__(self, preferred: str, index: str = None) -> None:
-        if preferred == '':
-            preferred = UNKNOWN_NAME
-
         if index is None:
             index = guess_index_name(preferred)
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -8,6 +8,7 @@ from profiles.database import UTCDateTime, db
 from profiles.utilities import guess_index_name
 
 ID_LENGTH = 8
+UNKNOWN_NAME = '(Unknown)'
 
 
 class OrcidToken(db.Model):
@@ -26,6 +27,9 @@ class OrcidToken(db.Model):
 
 class Name(object):
     def __init__(self, preferred: str, index: str = None) -> None:
+        if preferred == '':
+            preferred = UNKNOWN_NAME
+
         if index is None:
             index = guess_index_name(preferred)
 

--- a/test/test_oauth2.py
+++ b/test/test_oauth2.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 from requests import Request
 import requests_mock
 
-from profiles.models import Name, OrcidToken, Profile, UNKNOWN_NAME, db
+from profiles.models import Name, OrcidToken, Profile, db
 from profiles.utilities import expires_at
 
 
@@ -259,26 +259,6 @@ def test_it_creates_a_profile_when_exchanging(test_client: FlaskClient) -> None:
     assert str(profile.name) == 'Josiah Carberry'
 
 
-def test_it_creates_a_profile_with_an_empty_name_when_exchanging(test_client: FlaskClient) -> None:
-    with requests_mock.Mocker() as mocker:
-        mocker.post('http://www.example.com/server/token',
-                    json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
-                          'foo': 'bar', 'token_type': 'Bearer', 'orcid': '0000-0002-1825-0097',
-                          'name': ''})
-
-        test_client.post('/oauth2/token',
-                         data={'client_id': 'client_id', 'client_secret': 'client_secret',
-                               'redirect_uri': 'http://www.example.com/client/redirect',
-                               'grant_type': 'authorization_code', 'code': '1234'})
-
-    assert Profile.query.count() == 1
-
-    profile = Profile.query.filter_by(orcid='0000-0002-1825-0097').one()
-
-    assert profile.orcid == '0000-0002-1825-0097'
-    assert str(profile.name) == UNKNOWN_NAME
-
-
 def test_it_updates_a_profile_when_exchanging(test_client: FlaskClient) -> None:
     original_profile = Profile('a1b2c3d4', Name('Foo', 'Bar'), '0000-0002-1825-0097')
 
@@ -298,6 +278,44 @@ def test_it_updates_a_profile_when_exchanging(test_client: FlaskClient) -> None:
 
     assert Profile.query.count() == 1
     assert str(original_profile.name) == 'Josiah Carberry'
+
+
+def test_it_rejects_a_private_name_when_exchanging(test_client: FlaskClient) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.post('http://www.example.com/server/token',
+                    json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
+                          'foo': 'bar', 'token_type': 'Bearer', 'orcid': '0000-0002-1825-0097',
+                          'name': ''})
+
+        response = test_client.post('/oauth2/token',
+                                    data={'client_id': 'client_id',
+                                          'client_secret': 'client_secret',
+                                          'redirect_uri': 'http://www.example.com/client/redirect',
+                                          'grant_type': 'authorization_code', 'code': '1234'})
+
+    assert response.status_code == 400
+    assert response.headers.get('Content-Type') == 'application/json'
+
+
+def test_it_ignores_now_private_names_when_exchanging(test_client: FlaskClient) -> None:
+    original_profile = Profile('a1b2c3d4', Name('Foo Bar'), '0000-0002-1825-0097')
+
+    db.session.add(original_profile)
+    db.session.commit()
+
+    with requests_mock.Mocker() as mocker:
+        mocker.post('http://www.example.com/server/token',
+                    json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
+                          'foo': 'bar', 'token_type': 'Bearer', 'orcid': '0000-0002-1825-0097',
+                          'name': ''})
+
+        test_client.post('/oauth2/token',
+                         data={'client_id': 'client_id', 'client_secret': 'client_secret',
+                               'redirect_uri': 'http://www.example.com/client/redirect',
+                               'grant_type': 'authorization_code', 'code': '1234'})
+
+    assert Profile.query.count() == 1
+    assert str(original_profile.name) == 'Foo Bar'
 
 
 @freeze_time('2017-09-15 14:36:43')
@@ -382,6 +400,38 @@ def test_it_requires_a_bearer_token_type_when_exchanging(test_client: FlaskClien
         mocker.post('http://www.example.com/server/token',
                     json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
                           'token_type': 'foo'})
+
+        response = test_client.post('/oauth2/token',
+                                    data={'client_id': 'client_id',
+                                          'client_secret': 'client_secret',
+                                          'redirect_uri': 'http://www.example.com/client/redirect',
+                                          'grant_type': 'authorization_code', 'code': '1234'})
+
+    assert response.status_code == 500
+    assert response.headers.get('Content-Type') == 'application/problem+json'
+
+
+def test_it_requires_an_orcid_when_exchanging(test_client: FlaskClient) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.post('http://www.example.com/server/token',
+                    json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
+                          'token_type': 'Bearer'})
+
+        response = test_client.post('/oauth2/token',
+                                    data={'client_id': 'client_id',
+                                          'client_secret': 'client_secret',
+                                          'redirect_uri': 'http://www.example.com/client/redirect',
+                                          'grant_type': 'authorization_code', 'code': '1234'})
+
+    assert response.status_code == 500
+    assert response.headers.get('Content-Type') == 'application/problem+json'
+
+
+def test_it_requires_a_name_when_exchanging(test_client: FlaskClient) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.post('http://www.example.com/server/token',
+                    json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
+                          'token_type': 'Bearer', 'orcid': '0000-0002-1825-0097'})
 
         response = test_client.post('/oauth2/token',
                                     data={'client_id': 'client_id',


### PR DESCRIPTION
I assumed that no `name` would be provided if it were private (and so would fail), turns out that it's an empty string, which we've now persisted.

~Instead of hard-failing, this persists a clear fallback value.~