### PR TITLE
Gracefully fail on problems reading ORCID data

### DIFF
--- a/profiles/api/oauth2.py
+++ b/profiles/api/oauth2.py
@@ -155,7 +155,11 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
         try:
             orcid_record = orcid_client.get_record(profile.orcid, orcid_token.access_token)
             update_profile_from_orcid_record(profile, orcid_record)
-        except Exception as exception:
+        except RequestException as exception:
+            LOGGER.exception(exception)
+        except (LookupError, TypeError, ValueError) as exception:
+            # We appear to be misunderstanding the ORCID data structure, but let's not block the
+            # authentication flow.
             LOGGER.exception(exception)
 
         return make_response(jsonify(json_data), response.status_code)

--- a/profiles/api/oauth2.py
+++ b/profiles/api/oauth2.py
@@ -131,27 +131,40 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
             raise ValueError('Got token_type {}, expected Bearer'.format(
                 json_data.get('token_type')))
 
+        profile = _find_and_update_profile(json_data)
+        json_data['id'] = profile.id
+        orcid_token = _find_and_update_access_token(json_data)
+
+        _update_profile(profile, orcid_token)
+
+        return make_response(jsonify(json_data), response.status_code)
+
+    def _find_and_update_profile(token_data: dict) -> Profile:
         try:
-            profile = profiles.get_by_orcid(json_data['orcid'])
-            if json_data['name']:
-                profile.name = Name(json_data['name'])
+            profile = profiles.get_by_orcid(token_data['orcid'])
+            if token_data['name']:
+                profile.name = Name(token_data['name'])
         except ProfileNotFound:
-            if not json_data['name']:
+            if not token_data['name']:
                 raise InvalidRequest('No name visible')
-            profile = Profile(profiles.next_id(), Name(json_data['name']), json_data['orcid'])
+            profile = Profile(profiles.next_id(), Name(token_data['name']), token_data['orcid'])
             profiles.add(profile)
 
-        json_data['id'] = profile.id
+        return profile
 
+    def _find_and_update_access_token(token_data: dict) -> OrcidToken:
         try:
-            orcid_token = orcid_tokens.get(json_data['orcid'])
-            orcid_token.access_token = json_data['access_token']
-            orcid_token.expires_at = expires_at(json_data['expires_in'])
+            orcid_token = orcid_tokens.get(token_data['orcid'])
+            orcid_token.access_token = token_data['access_token']
+            orcid_token.expires_at = expires_at(token_data['expires_in'])
         except OrcidTokenNotFound:
-            orcid_token = OrcidToken(json_data['orcid'], json_data['access_token'],
-                                     expires_at(json_data['expires_in']))
+            orcid_token = OrcidToken(token_data['orcid'], token_data['access_token'],
+                                     expires_at(token_data['expires_in']))
             orcid_tokens.add(orcid_token)
 
+        return orcid_token
+
+    def _update_profile(profile: Profile, orcid_token: OrcidToken) -> None:
         try:
             orcid_record = orcid_client.get_record(profile.orcid, orcid_token.access_token)
             update_profile_from_orcid_record(profile, orcid_record)
@@ -161,7 +174,5 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
             # We appear to be misunderstanding the ORCID data structure, but let's not block the
             # authentication flow.
             LOGGER.exception(exception)
-
-        return make_response(jsonify(json_data), response.status_code)
 
     return blueprint

--- a/profiles/api/oauth2.py
+++ b/profiles/api/oauth2.py
@@ -155,7 +155,7 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
         try:
             orcid_record = orcid_client.get_record(profile.orcid, orcid_token.access_token)
             update_profile_from_orcid_record(profile, orcid_record)
-        except RequestException as exception:
+        except Exception as exception:
             LOGGER.exception(exception)
 
         return make_response(jsonify(json_data), response.status_code)

--- a/test/test_oauth2.py
+++ b/test/test_oauth2.py
@@ -284,6 +284,29 @@ def test_it_updates_a_profile_when_exchanging(test_client: FlaskClient) -> None:
     assert str(original_profile.name) == 'Josiah Carberry'
 
 
+def test_it_still_returns_200_when_failing_to_read_orcid_data(test_client: FlaskClient) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.post('http://www.example.com/server/token',
+                    json={'access_token': '1/fFAGRNJru1FTz70BzhT3Zg', 'expires_in': 3920,
+                          'foo': 'bar', 'token_type': 'Bearer', 'orcid': '0000-0002-1825-0097',
+                          'name': 'Josiah Carberry'})
+        mocker.get('http://www.example.com/api/v2.0/0000-0002-1825-0097/record',
+                   json={'person': {'name': 'this is unexpected'}})
+
+        response = test_client.post('/oauth2/token',
+                                    data={'client_id': 'client_id',
+                                          'client_secret': 'client_secret',
+                                          'redirect_uri': 'http://www.example.com/client/redirect',
+                                          'grant_type': 'authorization_code', 'code': '1234'})
+
+    assert response.status_code == 200
+    assert Profile.query.count() == 1
+
+    profile = Profile.query.filter_by(orcid='0000-0002-1825-0097').one()
+
+    assert str(profile.name) == 'Josiah Carberry'
+
+
 def test_it_rejects_a_private_name_when_exchanging(test_client: FlaskClient) -> None:
     with requests_mock.Mocker() as mocker:
         mocker.post('http://www.example.com/server/token',


### PR DESCRIPTION
For bugs like ELPP-3238, we probably should let users still authenticate rather than deny access. It means their profile will remain empty/incomplete.