### PR TITLE
ELPP-3238 Handle partial ORCID dates

### DIFF
--- a/migrations/versions/6e06221b94fa_.py
+++ b/migrations/versions/6e06221b94fa_.py
@@ -1,3 +1,4 @@
+from calendar import monthrange
 from datetime import datetime
 
 from alembic import op
@@ -68,8 +69,9 @@ def downgrade():
                           affiliation.starts_day or 1),
 
         if affiliation.ends_year:
-            ends = datetime(affiliation.ends_year, affiliation.ends_month or 1,
-                            affiliation.ends_day or 1)
+            ends = datetime(affiliation.ends_year, affiliation.ends_month or 12,
+                            affiliation.ends_day or
+                            monthrange(affiliation.ends_year, affiliation.ends_month or 12)[1])
         else:
             ends = None
 

--- a/migrations/versions/6e06221b94fa_.py
+++ b/migrations/versions/6e06221b94fa_.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '6e06221b94fa'
+down_revision = 'b35b975485ce'
+branch_labels = None
+depends_on = None
+
+affiliation_helper = sa.Table(
+    'affiliation',
+    sa.MetaData(),
+    sa.Column('id', sa.Text(), nullable=False),
+    sa.Column('starts', sa.DateTime(), nullable=True),
+    sa.Column('ends', sa.DateTime(), nullable=True),
+    sa.Column('starts_year', sa.Integer(), nullable=True),
+    sa.Column('starts_month', sa.Integer(), nullable=True),
+    sa.Column('starts_day', sa.Integer(), nullable=True),
+    sa.Column('ends_year', sa.Integer(), nullable=True),
+    sa.Column('ends_month', sa.Integer(), nullable=True),
+    sa.Column('ends_day', sa.Integer(), nullable=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    op.add_column('affiliation', sa.Column('starts_year', sa.Integer(), nullable=True))
+    op.add_column('affiliation', sa.Column('starts_month', sa.Integer(), nullable=True))
+    op.add_column('affiliation', sa.Column('starts_day', sa.Integer(), nullable=True))
+    op.add_column('affiliation', sa.Column('ends_year', sa.Integer(), nullable=True))
+    op.add_column('affiliation', sa.Column('ends_month', sa.Integer(), nullable=True))
+    op.add_column('affiliation', sa.Column('ends_day', sa.Integer(), nullable=True))
+
+    for affiliation in connection.execute(affiliation_helper.select()):
+        values = {
+            'starts_year': affiliation.starts.year,
+            'starts_month': affiliation.starts.month,
+            'starts_day': affiliation.starts.day,
+        }
+
+        if affiliation.ends:
+            values['ends_year'] = affiliation.ends.year
+            values['ends_month'] = affiliation.ends.month
+            values['ends_day'] = affiliation.ends.day
+
+        connection.execute(
+            affiliation_helper.update().where(
+                affiliation_helper.c.id == affiliation.id
+            ).values(**values)
+        )
+
+    op.alter_column('affiliation', 'starts_year', nullable=False)
+
+    op.drop_column('affiliation', 'starts')
+    op.drop_column('affiliation', 'ends')
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    op.add_column('affiliation', sa.Column('starts', sa.DateTime(), nullable=True))
+    op.add_column('affiliation', sa.Column('ends', sa.DateTime(), nullable=True))
+
+    for affiliation in connection.execute(affiliation_helper.select()):
+        starts = datetime(affiliation.starts_year, affiliation.starts_month or 1,
+                          affiliation.starts_day or 1),
+
+        if affiliation.ends_year:
+            ends = datetime(affiliation.ends_year, affiliation.ends_month or 1,
+                            affiliation.ends_day or 1)
+        else:
+            ends = None
+
+        connection.execute(
+            affiliation_helper.update().where(
+                affiliation_helper.c.id == affiliation.id
+            ).values(starts=starts, ends=ends)
+        )
+
+    op.alter_column('affiliation', 'starts', nullable=False)
+
+    op.drop_column('affiliation', 'starts_year')
+    op.drop_column('affiliation', 'starts_month')
+    op.drop_column('affiliation', 'starts_day')
+    op.drop_column('affiliation', 'ends_year')
+    op.drop_column('affiliation', 'ends_month')
+    op.drop_column('affiliation', 'ends_day')

--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -1,7 +1,8 @@
-from iso3166 import countries
-from pendulum import create as date
+from typing import Optional
 
-from profiles.models import Address, Affiliation, Name, Profile
+from iso3166 import countries
+
+from profiles.models import Address, Affiliation, Name, Profile, Date
 from profiles.orcid import VISIBILITY_PUBLIC
 
 
@@ -38,13 +39,8 @@ def _update_affiliations_from_orcid_record(profile: Profile, orcid_record: dict)
                 region=address.get('region'),
                 country=countries.get(address['country']),
             ),
-            starts=date(int(orcid_affiliation['start-date']['year']['value']),
-                        int(orcid_affiliation['start-date']['month']['value']),
-                        int(orcid_affiliation['start-date']['day']['value'])),
-            ends=date(int(orcid_affiliation['end-date']['year']['value']),
-                      int(orcid_affiliation['end-date']['month']['value']),
-                      int(orcid_affiliation['end-date']['day']['value']),
-                      hour=23, minute=59, second=59) if orcid_affiliation.get('end-date') else None,
+            starts=_convert_orcid_date(orcid_affiliation['start-date']),
+            ends=_convert_orcid_date(orcid_affiliation.get('end-date') or {}),
             restricted=orcid_affiliation['visibility'] != VISIBILITY_PUBLIC,
         )
         profile.add_affiliation(affiliation, index)
@@ -71,3 +67,12 @@ def _update_email_addresses_from_orcid_record(profile: Profile, orcid_record: di
     for orcid_email in orcid_emails:
         profile.add_email_address(orcid_email['email'], orcid_email['primary'],
                                   orcid_email['visibility'] != VISIBILITY_PUBLIC)
+
+
+def _convert_orcid_date(orcid_date: dict) -> Optional[Date]:
+    if 'year' in orcid_date:
+        year = int(orcid_date['year']['value'])
+        month = int(orcid_date['month']['value']) if orcid_date.get('month') else None
+        day = int(orcid_date['day']['value']) if orcid_date.get('day') else None
+
+        return Date(year, month, day)

--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from iso3166 import countries
 
-from profiles.models import Address, Affiliation, Name, Profile, Date
+from profiles.models import Address, Affiliation, Date, Name, Profile
 from profiles.orcid import VISIBILITY_PUBLIC
 
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -19,7 +19,7 @@ T = TypeVar('T')
 
 class Date(object):
     def __init__(self, year: int, month: int = None, day: int = None) -> None:
-        if day is not None and not month is not None:
+        if day is not None and month is None:
             raise ValueError('Month is missing')
         if month is not None and not 1 <= month <= 12:
             raise ValueError('Invalid date')
@@ -166,6 +166,9 @@ class Affiliation(db.Model):
         if self._ends and self._ends.year:
             return self._ends
 
+    def set_ends(self, ends: Optional[Date]) -> None:
+        self._ends = ends
+
     def is_current(self) -> bool:
         starts = pendulum.instance(self.starts.lowest_possible())
         ends = pendulum.instance(self.ends.highest_possible()) if self.ends else None
@@ -205,7 +208,7 @@ class Profile(db.Model):
                 existing_affiliation.organisation = affiliation.organisation
                 existing_affiliation.address = affiliation.address
                 existing_affiliation.starts = affiliation.starts
-                existing_affiliation._ends = affiliation.ends
+                existing_affiliation.set_ends(affiliation.ends)
                 existing_affiliation.restricted = affiliation.restricted
                 if position != existing_affiliation.position:
                     self.affiliations.remove(existing_affiliation)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -1,5 +1,6 @@
+from calendar import monthrange
 from datetime import datetime
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable, List, Optional, Type, TypeVar
 
 from iso3166 import Country
 import pendulum
@@ -12,6 +13,57 @@ from profiles.exceptions import AffiliationNotFound
 from profiles.utilities import guess_index_name
 
 ID_LENGTH = 8
+
+T = TypeVar('T')
+
+
+class Date(object):
+    def __init__(self, year: int, month: int = None, day: int = None) -> None:
+        if day is not None and not month is not None:
+            raise ValueError('Month is missing')
+        if month is not None and not 1 <= month <= 12:
+            raise ValueError('Invalid date')
+        if day is not None:
+            pendulum.date(year, month, day)
+
+        self.year = year
+        self.month = month
+        self.day = day
+
+    @classmethod
+    def from_datetime(cls: Type[T], datetime: datetime) -> T:
+        return cls(datetime.year, datetime.month, datetime.day)
+
+    def lowest_possible(self) -> datetime:
+        return datetime(self.year, self.month or 1, self.day or 1)
+
+    def highest_possible(self) -> datetime:
+        return datetime(self.year, self.month or 12,
+                        self.day or monthrange(self.year, self.month or 12)[1])
+
+    def __composite_values__(self) -> Iterable[Optional[int]]:
+        return self.year, self.month, self.day
+
+    def __str__(self) -> str:
+        parts = ['{0:04d}'.format(self.year)]
+        if self.month:
+            parts.append('{0:02d}'.format(self.month))
+        if self.day:
+            parts.append('{0:02d}'.format(self.day))
+
+        return '-'.join(parts)
+
+    def __repr__(self) -> str:
+        return '<Date %r>' % str(self)
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, Date) and \
+               other.year == self.year and \
+               other.month == self.month and \
+               other.day == self.day
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
 
 
 class OrcidToken(db.Model):
@@ -84,27 +136,39 @@ class Affiliation(db.Model):
     _city = db.Column(db.Text(), name='city', nullable=False)
     _region = db.Column(db.Text(), name='region')
     _country = db.Column(ISO3166Country, name='country', nullable=False)
-    starts = db.Column(UTCDateTime, nullable=False)
-    ends = db.Column(UTCDateTime)
+    starts = composite(Date, '_starts_year', '_starts_month', '_starts_day')
+    _starts_year = db.Column(db.Integer(), name='starts_year', nullable=False)
+    _starts_month = db.Column(db.Integer(), name='starts_month')
+    _starts_day = db.Column(db.Integer(), name='starts_day')
+    _ends = composite(Date, '_ends_year', '_ends_month', '_ends_day')
+    _ends_year = db.Column(db.Integer(), name='ends_year')
+    _ends_month = db.Column(db.Integer(), name='ends_month')
+    _ends_day = db.Column(db.Integer(), name='ends_day')
     restricted = db.Column(db.Boolean(), nullable=False)
     profile_id = db.Column(db.String(ID_LENGTH), db.ForeignKey('profile.id'))
     profile = db.relationship('Profile', back_populates='affiliations')
     position = db.Column(db.Integer())
 
     # pylint: disable=too-many-arguments
-    def __init__(self, affiliation_id: str, address: Address, organisation: str, starts: datetime,
-                 department: str = None, ends: datetime = None, restricted: bool = False) -> None:
+    def __init__(self, affiliation_id: str, address: Address, organisation: str, starts: Date,
+                 department: str = None, ends: Date = None, restricted: bool = False) -> None:
         self.id = affiliation_id
         self.department = department
         self.organisation = organisation
         self.address = address
-        self.starts = pendulum.timezone('utc').convert(starts)
-        self.ends = pendulum.timezone('utc').convert(ends) if ends else None
+        self.starts = starts
+        self._ends = ends
         self.restricted = restricted
 
+    @property
+    def ends(self) -> Optional[Date]:
+        # SQLAlchemy appears not to allow nullable composites columns.
+        if self._ends and self._ends.year:
+            return self._ends
+
     def is_current(self) -> bool:
-        starts = pendulum.instance(self.starts)
-        ends = pendulum.instance(self.ends) if self.ends else None
+        starts = pendulum.instance(self.starts.lowest_possible())
+        ends = pendulum.instance(self.ends.highest_possible()) if self.ends else None
 
         return starts.is_past() and (not ends or ends.is_future())
 
@@ -141,7 +205,7 @@ class Profile(db.Model):
                 existing_affiliation.organisation = affiliation.organisation
                 existing_affiliation.address = affiliation.address
                 existing_affiliation.starts = affiliation.starts
-                existing_affiliation.ends = affiliation.ends
+                existing_affiliation._ends = affiliation.ends
                 existing_affiliation.restricted = affiliation.restricted
                 if position != existing_affiliation.position:
                     self.affiliations.remove(existing_affiliation)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -34,6 +34,18 @@ class Date(object):
     def from_datetime(cls: Type[T], datetime: datetime) -> T:
         return cls(datetime.year, datetime.month, datetime.day)
 
+    @classmethod
+    def yesterday(cls: Type[T]) -> T:
+        return Date.from_datetime(pendulum.yesterday())
+
+    @classmethod
+    def today(cls: Type[T]) -> T:
+        return Date.from_datetime(pendulum.today())
+
+    @classmethod
+    def tomorrow(cls: Type[T]) -> T:
+        return Date.from_datetime(pendulum.tomorrow())
+
     def lowest_possible(self) -> datetime:
         return datetime(self.year, self.month or 1, self.day or 1)
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -1,6 +1,6 @@
 from calendar import monthrange
 from datetime import datetime
-from typing import Any, Iterable, List, Optional, Type, TypeVar
+from typing import Any, Iterable, List, Optional
 
 from iso3166 import Country
 import pendulum
@@ -13,8 +13,6 @@ from profiles.exceptions import AffiliationNotFound
 from profiles.utilities import guess_index_name
 
 ID_LENGTH = 8
-
-T = TypeVar('T')
 
 
 class Date(object):
@@ -31,20 +29,20 @@ class Date(object):
         self.day = day
 
     @classmethod
-    def from_datetime(cls: Type[T], datetime: datetime) -> T:
-        return cls(datetime.year, datetime.month, datetime.day)
+    def from_datetime(cls: 'Date', datetime: datetime) -> 'Date':
+        return Date(datetime.year, datetime.month, datetime.day)
 
     @classmethod
-    def yesterday(cls: Type[T]) -> T:
-        return Date.from_datetime(pendulum.yesterday())
+    def yesterday(cls: 'Date') -> 'Date':
+        return cls.from_datetime(pendulum.yesterday())
 
     @classmethod
-    def today(cls: Type[T]) -> T:
-        return Date.from_datetime(pendulum.today())
+    def today(cls: 'Date') -> 'Date':
+        return cls.from_datetime(pendulum.today())
 
     @classmethod
-    def tomorrow(cls: Type[T]) -> T:
-        return Date.from_datetime(pendulum.tomorrow())
+    def tomorrow(cls: 'Date') -> 'Date':
+        return cls.from_datetime(pendulum.tomorrow())
 
     def lowest_possible(self) -> datetime:
         return datetime(self.year, self.month or 1, self.day or 1)

--- a/test/commands/test_update_profile_from_orcid_record.py
+++ b/test/commands/test_update_profile_from_orcid_record.py
@@ -1,11 +1,8 @@
-from datetime import datetime
-
 from freezegun import freeze_time
 from iso3166 import countries
-import pendulum
 
 from profiles.commands import update_profile_from_orcid_record
-from profiles.models import Address, Affiliation, Name, Profile, Date
+from profiles.models import Address, Affiliation, Date, Name, Profile
 
 
 def test_it_updates_the_name():
@@ -113,8 +110,6 @@ def test_it_updates_affiliations():
     }}
 
     update_profile_from_orcid_record(profile, orcid_record)
-
-    utc = pendulum.timezone('utc')
 
     assert len(profile.affiliations) == 1
     assert profile.affiliations[0].department == 'Department 2'

--- a/test/models/test_affiliation.py
+++ b/test/models/test_affiliation.py
@@ -1,6 +1,4 @@
-from freezegun import freeze_time
 from iso3166 import countries
-import pendulum
 
 from profiles.models import Address, Affiliation, Date
 
@@ -38,19 +36,17 @@ def test_it_may_have_a_department():
     assert has_not.department is None
 
 
-@freeze_time('2017-01-01 00:00:00')
 def test_it_has_a_start_date():
-    starts = Date.from_datetime(pendulum.yesterday())
+    starts = Date.yesterday()
 
     affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', starts)
 
     assert affiliation.starts == starts
 
 
-@freeze_time('2017-01-01 00:00:00')
 def test_it_may_have_an_end_date():
-    starts = Date.from_datetime(pendulum.yesterday())
-    ends = Date.from_datetime(pendulum.tomorrow())
+    starts = Date.yesterday()
+    ends = Date.tomorrow()
 
     has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', starts, ends=ends)
     has_not = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', starts)
@@ -69,7 +65,7 @@ def test_it_may_be_restricted():
 
 
 def test_it_can_detect_if_current_without_ends_date():
-    starts = Date.from_datetime(pendulum.yesterday())
+    starts = Date.yesterday()
 
     address = Address(countries.get('gb'), 'City')
     affiliation = Affiliation('1', address=address, organisation='Org', starts=starts)
@@ -78,8 +74,8 @@ def test_it_can_detect_if_current_without_ends_date():
 
 
 def test_it_can_detect_if_current_with_ends_date():
-    starts = Date.from_datetime(pendulum.yesterday())
-    ends = Date.from_datetime(pendulum.tomorrow())
+    starts = Date.yesterday()
+    ends = Date.tomorrow()
 
     address = Address(countries.get('gb'), 'City')
     affiliation = Affiliation('1', address=address, organisation='Org', starts=starts, ends=ends)
@@ -88,7 +84,7 @@ def test_it_can_detect_if_current_with_ends_date():
 
 
 def test_it_can_detect_if_not_current_with_future_starts_date_and_no_ends_date():
-    starts = Date.from_datetime(pendulum.tomorrow())
+    starts = Date.tomorrow()
 
     address = Address(countries.get('gb'), 'City')
     affiliation = Affiliation('1', address=address, organisation='Org', starts=starts)
@@ -97,8 +93,8 @@ def test_it_can_detect_if_not_current_with_future_starts_date_and_no_ends_date()
 
 
 def test_it_can_detect_if_not_current_with_past_starts_date_and_past_ends_date():
-    starts = Date.from_datetime(pendulum.yesterday())
-    ends = Date.from_datetime(pendulum.yesterday())
+    starts = Date.yesterday()
+    ends = Date.yesterday()
 
     address = Address(countries.get('gb'), 'City')
     affiliation = Affiliation('1', address=address, organisation='Org', starts=starts, ends=ends)

--- a/test/models/test_affiliation.py
+++ b/test/models/test_affiliation.py
@@ -1,44 +1,40 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
 from freezegun import freeze_time
 from iso3166 import countries
 import pendulum
 
-from profiles.models import Address, Affiliation
+from profiles.models import Address, Affiliation, Date
 
 
 def test_it_can_be_printed():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now())
+    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert repr(affiliation) == "<Affiliation '1'>"
 
 
 def test_it_has_an_id():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now())
+    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert affiliation.id == '1'
 
 
 def test_it_has_an_address():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now())
+    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert affiliation.address == Address(countries.get('gb'), 'City')
 
 
 def test_it_has_an_organisation():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now())
+    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert affiliation.organisation == 'Organisation'
 
 
 def test_it_may_have_a_department():
-    has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', datetime.now(),
+    has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017),
                       department='Department')
-    has_not = Affiliation('2', Address(countries.get('gb'), 'City'), 'Organisation', datetime.now())
+    has_not = Affiliation('2', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert has.department == 'Department'
     assert has_not.department is None
@@ -46,82 +42,67 @@ def test_it_may_have_a_department():
 
 @freeze_time('2017-01-01 00:00:00')
 def test_it_has_a_start_date():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now())
+    starts = Date.from_datetime(pendulum.yesterday())
 
-    assert affiliation.starts == pendulum.timezone('utc').convert(datetime.now())
+    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', starts)
 
-
-@freeze_time('2017-01-01 00:00:00', 1)
-def test_it_converts_start_dates_to_utc():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1))))
-
-    assert affiliation.starts.isoformat() == '2017-01-01T00:00:00+00:00'
+    assert affiliation.starts == starts
 
 
 @freeze_time('2017-01-01 00:00:00')
 def test_it_may_have_an_end_date():
-    has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', datetime.now(),
-                      ends=datetime.now())
-    has_not = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', datetime.now())
+    starts = Date.from_datetime(pendulum.yesterday())
+    ends = Date.from_datetime(pendulum.tomorrow())
 
-    assert has.ends == pendulum.timezone('utc').convert(datetime.now())
+    has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', starts, ends=ends)
+    has_not = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', starts)
+
+    assert has.ends == ends
     assert has_not.ends is None
 
 
-@freeze_time('2017-01-01 00:00:00', 1)
-def test_it_converts_end_dates_to_utc():
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now(),
-                              ends=datetime(2017, 1, 1, 1, 0, 0,
-                                            tzinfo=timezone(timedelta(hours=1))))
-
-    assert affiliation.ends.isoformat() == '2017-01-01T00:00:00+00:00'
-
-
 def test_it_may_be_restricted():
-    has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', datetime.now(),
+    has = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017),
                       restricted=True)
-    has_not = Affiliation('2', Address(countries.get('gb'), 'City'), 'Organisation', datetime.now())
+    has_not = Affiliation('2', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert has.restricted is True
     assert has_not.restricted is False
 
 
 def test_it_can_detect_if_current_without_ends_date():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    starts = Date.from_datetime(pendulum.yesterday())
+
     address = Address(countries.get('gb'), 'City')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', starts=starts)
 
     assert affiliation.is_current() is True
 
 
 def test_it_can_detect_if_current_with_ends_date():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    ends_date = datetime(2100, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    starts = Date.from_datetime(pendulum.yesterday())
+    ends = Date.from_datetime(pendulum.tomorrow())
+
     address = Address(countries.get('gb'), 'City')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date, ends=ends_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', starts=starts, ends=ends)
 
     assert affiliation.is_current() is True
 
 
-@freeze_time('2018-01-01 00:00:00')
 def test_it_can_detect_if_not_current_with_future_starts_date_and_no_ends_date():
+    starts = Date.from_datetime(pendulum.tomorrow())
+
     address = Address(countries.get('gb'), 'City')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=datetime.now())
+    affiliation = Affiliation('1', address=address, organisation='Org', starts=starts)
 
     assert affiliation.is_current() is False
 
 
 def test_it_can_detect_if_not_current_with_past_starts_date_and_past_ends_date():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    ends_date = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    starts = Date.from_datetime(pendulum.yesterday())
+    ends = Date.from_datetime(pendulum.yesterday())
+
     address = Address(countries.get('gb'), 'City')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date, ends=ends_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', starts=starts, ends=ends)
 
     assert affiliation.is_current() is False

--- a/test/models/test_affiliation.py
+++ b/test/models/test_affiliation.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from freezegun import freeze_time
 from iso3166 import countries
 import pendulum

--- a/test/models/test_date.py
+++ b/test/models/test_date.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-import pytest
 from freezegun import freeze_time
+import pytest
 
 from profiles.models import Date
 

--- a/test/models/test_date.py
+++ b/test/models/test_date.py
@@ -30,9 +30,28 @@ def test_it_casts_to_a_string():
 def test_it_can_be_created_from_a_datetime():
     date = Date.from_datetime(datetime.now())
 
-    assert date.year == 2017
-    assert date.month == 1
-    assert date.day == 2
+    assert date == Date(2017, 1, 2)
+
+
+@freeze_time('2017-01-02 00:00:00')
+def test_it_can_be_created_for_yesterday():
+    date = Date.yesterday()
+
+    assert date == Date(2017, 1, 1)
+
+
+@freeze_time('2017-01-02 00:00:00')
+def test_it_can_be_created_for_today():
+    date = Date.today()
+
+    assert date == Date(2017, 1, 2)
+
+
+@freeze_time('2017-01-02 00:00:00')
+def test_it_can_be_created_for_tomorrow():
+    date = Date.tomorrow()
+
+    assert date == Date(2017, 1, 3)
 
 
 def test_it_has_a_year():

--- a/test/models/test_date.py
+++ b/test/models/test_date.py
@@ -1,0 +1,118 @@
+from datetime import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from profiles.models import Date
+
+
+def test_it_can_be_printed():
+    date1 = Date(2017)
+    date2 = Date(2017, 1)
+    date3 = Date(2017, 1, 2)
+
+    assert repr(date1) == "<Date '2017'>"
+    assert repr(date2) == "<Date '2017-01'>"
+    assert repr(date3) == "<Date '2017-01-02'>"
+
+
+def test_it_casts_to_a_string():
+    date1 = Date(2017)
+    date2 = Date(2017, 1)
+    date3 = Date(2017, 1, 2)
+
+    assert str(date1) == '2017'
+    assert str(date2) == '2017-01'
+    assert str(date3) == '2017-01-02'
+
+
+@freeze_time('2017-01-02 00:00:00')
+def test_it_can_be_created_from_a_datetime():
+    date = Date.from_datetime(datetime.now())
+
+    assert date.year == 2017
+    assert date.month == 1
+    assert date.day == 2
+
+
+def test_it_has_a_year():
+    date = Date(2017)
+
+    assert date.year == 2017
+
+
+def test_it_may_have_a_month():
+    has = Date(2017, 1)
+    has_not = Date(2017)
+
+    assert has.month == 1
+    assert has_not.month is None
+
+
+def test_it_must_have_a_valid_month():
+    with pytest.raises(ValueError):
+        Date(2017, 0)
+    with pytest.raises(ValueError):
+        Date(2017, 13)
+
+
+def test_it_may_have_a_day():
+    has = Date(2016, 2, 29)
+    has_not = Date(2017, 1)
+
+    assert has.day == 29
+    assert has_not.day is None
+
+
+def test_it_must_have_a_month_to_have_a_day():
+    with pytest.raises(ValueError):
+        Date(2017, None, 2)
+
+
+def test_it_must_be_a_valid_date():
+    with pytest.raises(ValueError):
+        Date(2017, 0, 0)
+    with pytest.raises(ValueError):
+        Date(2017, 13, 31)
+    with pytest.raises(ValueError):
+        Date(2017, 12, 32)
+    with pytest.raises(ValueError):
+        Date(2017, 2, 29)
+
+
+def test_it_can_become_the_lowest_possible_datetime():
+    date1 = Date(2017)
+    date2 = Date(2017, 2)
+    date3 = Date(2017, 3, 4)
+
+    assert date1.lowest_possible().isoformat() == '2017-01-01T00:00:00'
+    assert date2.lowest_possible().isoformat() == '2017-02-01T00:00:00'
+    assert date3.lowest_possible().isoformat() == '2017-03-04T00:00:00'
+
+
+def test_it_can_become_the_highest_possible_datetime():
+    date1 = Date(2017)
+    date2 = Date(2017, 2)
+    date3 = Date(2016, 2)
+    date4 = Date(2017, 3, 4)
+
+    assert date1.highest_possible().isoformat() == '2017-12-31T00:00:00'
+    assert date2.highest_possible().isoformat() == '2017-02-28T00:00:00'
+    assert date3.highest_possible().isoformat() == '2016-02-29T00:00:00'
+    assert date4.highest_possible().isoformat() == '2017-03-04T00:00:00'
+
+
+def test_it_can_be_compared():
+    date1 = Date(2017)
+    date2 = Date(2017)
+    date3 = Date(2017, 1)
+    date4 = Date(2017, 1)
+    date5 = Date(2017, 1, 2)
+    date6 = Date(2017, 1, 2)
+
+    assert date1 == date2
+    assert date1 != date3
+    assert date3 == date4
+    assert date3 != date1
+    assert date5 == date6
+    assert date5 != date1

--- a/test/models/test_profile.py
+++ b/test/models/test_profile.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timedelta, timezone
 
 from iso3166 import countries
+import pendulum
 import pytest
 
 from profiles.exceptions import AffiliationNotFound
-from profiles.models import Address, Affiliation, Name, Profile
+from profiles.models import Address, Affiliation, Name, Profile, Date
 
 
 def test_it_can_be_printed():
@@ -33,8 +34,7 @@ def test_it_has_an_orcid():
 
 def test_it_can_have_affiliations():
     profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
-    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation',
-                              datetime.now())
+    affiliation = Affiliation('1', Address(countries.get('gb'), 'City'), 'Organisation', Date(2017))
 
     assert len(profile.affiliations) == 0
 
@@ -51,114 +51,69 @@ def test_it_can_have_affiliations():
 
 
 def test_it_can_get_current_affiliations():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    start_date2 = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-
-    past_end_date = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    yesterday = Date.from_datetime(pendulum.yesterday())
+    tomorrow = Date.from_datetime(pendulum.tomorrow())
 
     address = Address(countries.get('gb'), 'City')
 
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep', starts=start_date2)
-    affiliation3 = Affiliation('3', address=address, organisation='Org2',
-                               department='Dep', starts=start_date, ends=past_end_date)
+    affiliation1 = Affiliation('1', address=address, organisation='Org', starts=yesterday)
+    affiliation2 = Affiliation('2', address=address, organisation='Org', starts=yesterday,
+                               ends=tomorrow)
+    affiliation3 = Affiliation('3', address=address, organisation='Org', starts=tomorrow)
+    affiliation4 = Affiliation('4', address=address, organisation='Org', starts=yesterday,
+                               ends=yesterday)
 
     profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
 
     # current affiliations
-    profile.add_affiliation(affiliation)
+    profile.add_affiliation(affiliation1)
     profile.add_affiliation(affiliation2)
+
+    # future affiliation, should not be returned with current affiliations
+    profile.add_affiliation(affiliation3)
 
     # past affiliation, should not be returned with current affiliations
-    profile.add_affiliation(affiliation3)
-
-    assert len(profile.get_affiliations()) == 2
-
-
-def test_it_can_get_all_affiliations_including_non_current():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    start_date2 = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-
-    past_end_date = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-
-    address = Address(countries.get('gb'), 'City')
-
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep', starts=start_date2)
-    affiliation3 = Affiliation('3', address=address, organisation='Org2',
-                               department='Dep', starts=start_date, ends=past_end_date)
-
-    profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
-
-    # current affiliations
-    profile.add_affiliation(affiliation)
-    profile.add_affiliation(affiliation2)
-
-    # past affiliation, should be returned when requesting 'all' affiliations
-    profile.add_affiliation(affiliation3)
-
-    assert len(profile.get_affiliations(current_only=False)) == 3
-
-
-def test_it_can_get_current_affiliations_in_position_based_order():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    start_date2 = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-
-    address = Address(countries.get('gb'), 'City')
-
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep', starts=start_date2)
-    affiliation3 = Affiliation('3', address=address, organisation='Org3',
-                               department='Dep', starts=start_date)
-
-    profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
-
-    profile.add_affiliation(affiliation, position=1)
-    profile.add_affiliation(affiliation2, position=0)
-    profile.add_affiliation(affiliation3, position=2)
+    profile.add_affiliation(affiliation4)
 
     affiliations = profile.get_affiliations()
 
+    assert len(affiliations) == 2
     assert affiliations[0] == affiliation2
-    assert affiliations[1] == affiliation
-    assert affiliations[2] == affiliation3
+    assert affiliations[1] == affiliation1
 
 
-def test_it_can_get_all_affiliations_in_position_based_order():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    start_date2 = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-
-    past_end_date = datetime(2017, 2, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+def test_it_can_get_all_affiliations_including_non_current():
+    yesterday = Date.from_datetime(pendulum.yesterday())
+    tomorrow = Date.from_datetime(pendulum.tomorrow())
 
     address = Address(countries.get('gb'), 'City')
 
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep', starts=start_date2)
-    affiliation3 = Affiliation('3', address=address, organisation='Org2',
-                               department='Dep', starts=start_date, ends=past_end_date)
+    affiliation1 = Affiliation('1', address=address, organisation='Org', starts=yesterday)
+    affiliation2 = Affiliation('2', address=address, organisation='Org', starts=yesterday,
+                               ends=tomorrow)
+    affiliation3 = Affiliation('3', address=address, organisation='Org', starts=tomorrow)
+    affiliation4 = Affiliation('4', address=address, organisation='Org', starts=yesterday,
+                               ends=yesterday)
 
     profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
 
     # current affiliations
-    profile.add_affiliation(affiliation, position=1)
-    profile.add_affiliation(affiliation2, position=0)
+    profile.add_affiliation(affiliation1)
+    profile.add_affiliation(affiliation2)
+
+    # future affiliation, should be returned when requesting 'all' affiliations
+    profile.add_affiliation(affiliation3)
 
     # past affiliation, should be returned when requesting 'all' affiliations
-    profile.add_affiliation(affiliation3, position=2)
+    profile.add_affiliation(affiliation4)
 
     affiliations = profile.get_affiliations(current_only=False)
 
-    assert affiliations[0] == affiliation2
-    assert affiliations[1] == affiliation
-    assert affiliations[2] == affiliation3
+    assert len(affiliations) == 4
+    assert affiliations[0] == affiliation4
+    assert affiliations[1] == affiliation3
+    assert affiliations[2] == affiliation2
+    assert affiliations[3] == affiliation1
 
 
 def test_it_can_get_only_non_restricted_email_addresses():
@@ -182,16 +137,14 @@ def test_it_can_get_all_email_addresses_including_restricted():
 
 
 def test_it_can_get_all_non_restricted_affiliations():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    yesterday = Date.from_datetime(pendulum.yesterday())
 
     address = Address(countries.get('gb'), 'City')
 
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep', starts=start_date, restricted=True)
-    affiliation3 = Affiliation('3', address=address, organisation='Org3',
-                               department='Dep', starts=start_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', starts=yesterday)
+    affiliation2 = Affiliation('2', address=address, organisation='Org', starts=yesterday,
+                               restricted=True)
+    affiliation3 = Affiliation('3', address=address, organisation='Org', starts=yesterday)
 
     profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
 
@@ -205,16 +158,14 @@ def test_it_can_get_all_non_restricted_affiliations():
 
 
 def test_it_can_get_all_affiliations_including_restricted():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    yesterday = Date.from_datetime(pendulum.yesterday())
 
     address = Address(countries.get('gb'), 'City')
 
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep', starts=start_date, restricted=True)
-    affiliation3 = Affiliation('3', address=address, organisation='Org3',
-                               department='Dep', starts=start_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', starts=yesterday)
+    affiliation2 = Affiliation('2', address=address, organisation='Org', starts=yesterday,
+                               restricted=True)
+    affiliation3 = Affiliation('3', address=address, organisation='Org', starts=yesterday)
 
     profile = Profile('12345678', Name('foo'), '0000-0002-1825-0097')
 

--- a/test/models/test_profile.py
+++ b/test/models/test_profile.py
@@ -1,11 +1,9 @@
-from datetime import datetime, timedelta, timezone
-
 from iso3166 import countries
 import pendulum
 import pytest
 
 from profiles.exceptions import AffiliationNotFound
-from profiles.models import Address, Affiliation, Name, Profile, Date
+from profiles.models import Address, Affiliation, Date, Name, Profile
 
 
 def test_it_can_be_printed():

--- a/test/models/test_profile.py
+++ b/test/models/test_profile.py
@@ -1,5 +1,4 @@
 from iso3166 import countries
-import pendulum
 import pytest
 
 from profiles.exceptions import AffiliationNotFound
@@ -49,8 +48,8 @@ def test_it_can_have_affiliations():
 
 
 def test_it_can_get_current_affiliations():
-    yesterday = Date.from_datetime(pendulum.yesterday())
-    tomorrow = Date.from_datetime(pendulum.tomorrow())
+    yesterday = Date.yesterday()
+    tomorrow = Date.tomorrow()
 
     address = Address(countries.get('gb'), 'City')
 
@@ -81,8 +80,8 @@ def test_it_can_get_current_affiliations():
 
 
 def test_it_can_get_all_affiliations_including_non_current():
-    yesterday = Date.from_datetime(pendulum.yesterday())
-    tomorrow = Date.from_datetime(pendulum.tomorrow())
+    yesterday = Date.yesterday()
+    tomorrow = Date.tomorrow()
 
     address = Address(countries.get('gb'), 'City')
 
@@ -135,7 +134,7 @@ def test_it_can_get_all_email_addresses_including_restricted():
 
 
 def test_it_can_get_all_non_restricted_affiliations():
-    yesterday = Date.from_datetime(pendulum.yesterday())
+    yesterday = Date.yesterday()
 
     address = Address(countries.get('gb'), 'City')
 
@@ -156,7 +155,7 @@ def test_it_can_get_all_non_restricted_affiliations():
 
 
 def test_it_can_get_all_affiliations_including_restricted():
-    yesterday = Date.from_datetime(pendulum.yesterday())
+    yesterday = Date.yesterday()
 
     address = Address(countries.get('gb'), 'City')
 

--- a/test/serializer/test_normalize.py
+++ b/test/serializer/test_normalize.py
@@ -1,9 +1,7 @@
-from datetime import datetime, timedelta, timezone
-
-import pendulum
 from iso3166 import countries
+import pendulum
 
-from profiles.models import Address, Affiliation, EmailAddress, Name, Profile, Date
+from profiles.models import Address, Affiliation, Date, EmailAddress, Name, Profile
 from profiles.serializer.normalizer import normalize
 
 

--- a/test/serializer/test_normalize.py
+++ b/test/serializer/test_normalize.py
@@ -1,5 +1,4 @@
 from iso3166 import countries
-import pendulum
 
 from profiles.models import Address, Affiliation, Date, EmailAddress, Name, Profile
 from profiles.serializer.normalizer import normalize
@@ -73,7 +72,7 @@ def test_it_normalizes_profile_with_multiple_email_addresses_with_primary_addres
 
 
 def test_it_normalizes_profile_with_an_affiliation():
-    starts = Date.from_datetime(pendulum.yesterday())
+    starts = Date.yesterday()
     address = Address(countries.get('gb'), 'City', 'Region')
     affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
                               starts=starts)
@@ -116,7 +115,7 @@ def test_it_normalizes_profile_with_an_affiliation():
 
 
 def test_it_normalizes_profile_with_affiliations():
-    starts = Date.from_datetime(pendulum.yesterday())
+    starts = Date.yesterday()
     address = Address(countries.get('gb'), 'City', 'Region')
     address2 = Address(countries.get('gb'), 'City2', 'Region2')
     affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
@@ -172,7 +171,7 @@ def test_it_normalizes_profile_with_affiliations():
 
 
 def test_it_normalizes_affiliation():
-    starts = Date.from_datetime(pendulum.yesterday())
+    starts = Date.yesterday()
     address = Address(countries.get('gb'), 'City', 'Region')
     affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
                               starts=starts)

--- a/test/serializer/test_normalize.py
+++ b/test/serializer/test_normalize.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timedelta, timezone
 
+import pendulum
 from iso3166 import countries
 
-from profiles.models import Address, Affiliation, EmailAddress, Name, Profile
+from profiles.models import Address, Affiliation, EmailAddress, Name, Profile, Date
 from profiles.serializer.normalizer import normalize
 
 
@@ -74,10 +75,10 @@ def test_it_normalizes_profile_with_multiple_email_addresses_with_primary_addres
 
 
 def test_it_normalizes_profile_with_an_affiliation():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    starts = Date.from_datetime(pendulum.yesterday())
     address = Address(countries.get('gb'), 'City', 'Region')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
+                              starts=starts)
     profile = Profile('12345678', Name('Foo Bar', 'Bar, Foo'))
 
     profile.add_affiliation(affiliation)
@@ -117,13 +118,13 @@ def test_it_normalizes_profile_with_an_affiliation():
 
 
 def test_it_normalizes_profile_with_affiliations():
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    starts = Date.from_datetime(pendulum.yesterday())
     address = Address(countries.get('gb'), 'City', 'Region')
     address2 = Address(countries.get('gb'), 'City2', 'Region2')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
-    affiliation2 = Affiliation('2', address=address2, organisation='Org2',
-                               department='Dep', starts=start_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
+                              starts=starts)
+    affiliation2 = Affiliation('2', address=address2, organisation='Org2', department='Dep',
+                               starts=starts)
 
     profile = Profile('12345678', Name('Foo Bar', 'Bar, Foo'))
 
@@ -173,9 +174,10 @@ def test_it_normalizes_profile_with_affiliations():
 
 
 def test_it_normalizes_affiliation():
+    starts = Date.from_datetime(pendulum.yesterday())
     address = Address(countries.get('gb'), 'City', 'Region')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=datetime.now())
+    affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
+                              starts=starts)
 
     assert normalize(affiliation) == {
         "name": [

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2,7 +2,6 @@ import json
 
 from flask.testing import FlaskClient
 from iso3166 import countries
-import pendulum
 
 from profiles.models import Address, Affiliation, Date, Name, Profile, db
 from profiles.utilities import validate_json
@@ -207,11 +206,9 @@ def test_does_not_contain_restricted_email_addresses(test_client: FlaskClient) -
 
 
 def test_get_profile_response_contains_affiliations(test_client: FlaskClient) -> None:
-    starts = Date.from_datetime(pendulum.yesterday())
-
     address = Address(country=countries.get('gb'), city='City', region='Region')
     affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
-                              starts=starts)
+                              starts=Date.yesterday())
 
     profile = Profile('a1b2c3d4', Name('Foo Bar'), '0000-0002-1825-0097')
 
@@ -236,14 +233,12 @@ def test_get_profile_response_contains_affiliations(test_client: FlaskClient) ->
 
 
 def test_it_does_not_return_restricted_affiliations(test_client: FlaskClient) -> None:
-    starts = Date.from_datetime(pendulum.yesterday())
-
     address = Address(country=countries.get('gb'), city='City', region='Region')
     affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
-                              starts=starts)
+                              starts=Date.yesterday())
 
     affiliation2 = Affiliation('2', address=address, organisation='Org2', department='Dep2',
-                               starts=starts, restricted=True)
+                               starts=Date.yesterday(), restricted=True)
 
     profile = Profile('a1b2c3d4', Name('Foo Bar'), '0000-0002-1825-0097')
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,10 +1,11 @@
 import json
 from datetime import datetime, timedelta, timezone
 
+import pendulum
 from flask.testing import FlaskClient
 from iso3166 import countries
 
-from profiles.models import Address, Affiliation, Name, Profile, db
+from profiles.models import Address, Affiliation, Name, Profile, db, Date
 from profiles.utilities import validate_json
 
 
@@ -207,10 +208,11 @@ def test_does_not_contain_restricted_email_addresses(test_client: FlaskClient) -
 
 
 def test_get_profile_response_contains_affiliations(test_client: FlaskClient) -> None:
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+    starts = Date.from_datetime(pendulum.yesterday())
+
     address = Address(country=countries.get('gb'), city='City', region='Region')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
+    affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
+                              starts=starts)
 
     profile = Profile('a1b2c3d4', Name('Foo Bar'), '0000-0002-1825-0097')
 
@@ -235,13 +237,14 @@ def test_get_profile_response_contains_affiliations(test_client: FlaskClient) ->
 
 
 def test_it_does_not_return_restricted_affiliations(test_client: FlaskClient) -> None:
-    start_date = datetime(2017, 1, 1, 1, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    address = Address(country=countries.get('gb'), city='City', region='Region')
-    affiliation = Affiliation('1', address=address, organisation='Org',
-                              department='Dep', starts=start_date)
+    starts = Date.from_datetime(pendulum.yesterday())
 
-    affiliation2 = Affiliation('2', address=address, organisation='Org2',
-                               department='Dep2', starts=start_date, restricted=True)
+    address = Address(country=countries.get('gb'), city='City', region='Region')
+    affiliation = Affiliation('1', address=address, organisation='Org', department='Dep',
+                              starts=starts)
+
+    affiliation2 = Affiliation('2', address=address, organisation='Org2', department='Dep2',
+                               starts=starts, restricted=True)
 
     profile = Profile('a1b2c3d4', Name('Foo Bar'), '0000-0002-1825-0097')
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,11 +1,10 @@
 import json
-from datetime import datetime, timedelta, timezone
 
-import pendulum
 from flask.testing import FlaskClient
 from iso3166 import countries
+import pendulum
 
-from profiles.models import Address, Affiliation, Name, Profile, db, Date
+from profiles.models import Address, Affiliation, Date, Name, Profile, db
 from profiles.utilities import validate_json
 
 


### PR DESCRIPTION
Stores dates in separate parts, as we might be missing the month and day.

Would have like to have used the [EDTF library](https://github.com/ixc/python-edtf), but doesn't support Python 3 (and is untested etc).