### PR TITLE
Missing lock on profiles--prod deploy

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -6,9 +6,11 @@ elifePipeline {
     }
 
     stage 'Deploy to prod', {
-        elifeDeploySlackNotification 'profiles', 'prod'
-        elifeGitMoveToBranch commit, 'master'
-        builderDeployRevision 'profiles--prod', commit
-        builderSmokeTests 'profiles--prod', '/srv/profiles'
+        lock ('profiles--prod') {
+            elifeDeploySlackNotification 'profiles', 'prod'
+            elifeGitMoveToBranch commit, 'master'
+            builderDeployRevision 'profiles--prod', commit
+            builderSmokeTests 'profiles--prod', '/srv/profiles'
+        }
     }
 }


### PR DESCRIPTION
This isn't generally a problem because only one build is performed at a time, but better to be consistent in all environments.