### PR TITLE
Use JMESPath to pick data out of the ORCID API response

### DIFF
--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
-import jmespath
 from iso3166 import countries
+import jmespath
 
 from profiles.models import Address, Affiliation, Date, Name, Profile
 from profiles.orcid import VISIBILITY_PUBLIC

--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -23,17 +23,16 @@ def extract_email_addresses(orcid_record: dict, only_verified: bool = True) -> L
 
 
 def _update_name_from_orcid_record(profile: Profile, orcid_record: dict) -> None:
-    if 'name' in orcid_record.get('person', {}):
-        given_name = jmespath.search('person.name."given-names".value', orcid_record)
-        family_name = jmespath.search('person.name."family-name".value', orcid_record)
+    given_name = jmespath.search('person.name."given-names".value', orcid_record)
+    family_name = jmespath.search('person.name."family-name".value', orcid_record)
 
-        if given_name and family_name:
-            profile.name = Name('{} {}'.format(given_name, family_name),
-                                '{}, {}'.format(family_name, given_name))
-        elif given_name:
-            profile.name = Name(given_name, given_name)
-        elif family_name:
-            profile.name = Name(family_name, family_name)
+    if given_name and family_name:
+        profile.name = Name('{} {}'.format(given_name, family_name),
+                            '{}, {}'.format(family_name, given_name))
+    elif given_name:
+        profile.name = Name(given_name, given_name)
+    elif family_name:
+        profile.name = Name(family_name, family_name)
 
 
 def _update_affiliations_from_orcid_record(profile: Profile, orcid_record: dict) -> None:

--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+import jmespath
 from iso3166 import countries
 
 from profiles.models import Address, Affiliation, Date, Name, Profile
@@ -13,7 +14,7 @@ def update_profile_from_orcid_record(profile: Profile, orcid_record: dict) -> No
 
 
 def extract_email_addresses(orcid_record: dict, only_verified: bool = True) -> List[dict]:
-    orcid_emails = orcid_record.get('person', {}).get('emails', {}).get('email', {})
+    orcid_emails = jmespath.search('person.emails.email[*]', orcid_record) or []
 
     if only_verified:
         orcid_emails = list(filter(lambda x: x['verified'], orcid_emails))
@@ -23,8 +24,8 @@ def extract_email_addresses(orcid_record: dict, only_verified: bool = True) -> L
 
 def _update_name_from_orcid_record(profile: Profile, orcid_record: dict) -> None:
     if 'name' in orcid_record.get('person', {}):
-        given_name = orcid_record['person']['name'].get('given-names', {}).get('value')
-        family_name = orcid_record['person']['name'].get('family-name', {}).get('value')
+        given_name = jmespath.search('person.name."given-names".value', orcid_record)
+        family_name = jmespath.search('person.name."family-name".value', orcid_record)
 
         if given_name and family_name:
             profile.name = Name('{} {}'.format(given_name, family_name),
@@ -36,8 +37,8 @@ def _update_name_from_orcid_record(profile: Profile, orcid_record: dict) -> None
 
 
 def _update_affiliations_from_orcid_record(profile: Profile, orcid_record: dict) -> None:
-    orcid_affiliations = orcid_record.get('activities-summary', {}).get('employments', {}).get(
-        'employment-summary', {})
+    orcid_affiliations = jmespath.search('"activities-summary".employments."employment-summary"[*]',
+                                         orcid_record) or []
 
     found_affiliation_ids = set()
     for index, orcid_affiliation in enumerate(orcid_affiliations):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,15 @@ alembic==0.9.5
 -e git+https://github.com/elifesciences/bus-sdk-python.git@49a0b0ecc55f99bc55a61f3e9b613ea88e3ff5a5#egg=bus-sdk-python
 -e git+https://github.com/elifesciences/api-validator-python.git@2971a2146321d48cc88c9c9f36e8fd72740dbfee#egg=api-validator-python
 astroid==1.5.3
+attrs==17.3.0
 blinker==1.4
+boto3==1.4.7
+botocore==1.7.36
 certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
+coverage==4.4.2
+docutils==0.14
 Faker==0.8.6
 flake8==3.4.1
 flake8-import-order==0.13
@@ -19,8 +24,9 @@ idna==2.6
 iso3166==0.8
 isort==4.2.15
 itsdangerous==0.24
-jsonschema==2.6.0
 Jinja2==2.9.6
+jmespath==0.9.3
+jsonschema==2.6.0
 lazy-object-proxy==1.3.1
 Mako==1.0.7
 MarkupSafe==1.0
@@ -43,8 +49,10 @@ PyYAML==3.12
 requests==2.18.4
 requests-mock==1.3.0
 retrying==1.3.3
+s3transfer==0.1.11
 six==1.10.0
 SQLAlchemy==1.1.14
+text-unidecode==1.1
 tzlocal==1.4
 urllib3==1.22
 uWSGI==2.0.15

--- a/test/commands/test_update_profile_from_orcid_record.py
+++ b/test/commands/test_update_profile_from_orcid_record.py
@@ -2,6 +2,7 @@ from hypothesis import given
 from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.strategies import sampled_from
 from iso3166 import countries
+import pytest
 
 from profiles.commands import extract_email_addresses, update_profile_from_orcid_record
 from profiles.models import Address, Affiliation, Date, Name, Profile
@@ -66,9 +67,14 @@ def test_it_updates_the_name(given_names: str, family_name: str):
     assert profile.name.index == '{}, {}'.format(family_name, given_names)
 
 
-def test_it_does_not_updates_the_name_if_its_missing():
+@pytest.mark.parametrize('name', [
+    ({}),
+    ({'family-name': None, 'given-names': None}),
+    ({'family-name': {'value': ''}, 'given-names': {'value': ''}}),
+])
+def test_it_does_not_updates_the_name_if_its_missing(name):
     profile = Profile('12345678', Name('Old Name'))
-    orcid_record = {'person': {'name': {}}}
+    orcid_record = {'person': {'name': name}}
 
     update_profile_from_orcid_record(profile, orcid_record)
 


### PR DESCRIPTION
Seems unclear whether the ORCID responses should omit values or leave them as `null`, but they do the latter. JMESPath is probably a better way to traverse the uncertain structure (this doesn't do it _everywhere_).