### PR TITLE
Remove API version from webhook URI

### DIFF
--- a/profiles/orcid.py
+++ b/profiles/orcid.py
@@ -20,7 +20,7 @@ class OrcidClient(object):
         LOGGER.debug('Requesting ORCID record for %s', format(orcid))
 
         try:
-            response = self._get_request('{}/record'.format(orcid), access_token)
+            response = self._get_request('{}/{}/record'.format(API_VERSION, orcid), access_token)
         except RequestException as exception:
             LOGGER.warning('Failed to load ORCID record for %s (%s)', orcid, str(exception))
             raise exception
@@ -64,7 +64,7 @@ class OrcidClient(object):
         if headers is None:
             headers = {}
 
-        uri = '{}/{}/{}'.format(self.api_uri, API_VERSION, path)
+        uri = '{}/{}'.format(self.api_uri, path)
         headers['Authorization'] = 'Bearer ' + access_token
 
         response = request(method, uri, headers=headers)

--- a/test/test_orcid.py
+++ b/test/test_orcid.py
@@ -19,7 +19,7 @@ def test_it_gets_a_record(orcid_client: OrcidClient):
 
 def test_it_sets_a_webhook(orcid_client: OrcidClient):
     with requests_mock.Mocker() as mocker:
-        mocker.put('http://www.example.com/api/v2.1/0000-0002-1825-0097/webhook/'
+        mocker.put('http://www.example.com/api/0000-0002-1825-0097/webhook/'
                    'http%3A%2F%2Flocalhost%2Forcid-webhook%2F0000-0002-1825-0097',
                    request_headers={'Authorization': 'Bearer 1/fFAGRNJru1FTz70BzhT3Zg'})
 
@@ -30,7 +30,7 @@ def test_it_sets_a_webhook(orcid_client: OrcidClient):
 
 def test_it_removes_a_webhook(orcid_client: OrcidClient):
     with requests_mock.Mocker() as mocker:
-        mocker.delete('http://www.example.com/api/v2.1/0000-0002-1825-0097/webhook/'
+        mocker.delete('http://www.example.com/api/0000-0002-1825-0097/webhook/'
                       'http%3A%2F%2Flocalhost%2Forcid-webhook%2F0000-0002-1825-0097',
                       request_headers={'Authorization': 'Bearer 1/fFAGRNJru1FTz70BzhT3Zg'})
 


### PR DESCRIPTION
Should now match https://members.orcid.org/api/tutorial/webhooks.