### PR TITLE
[WIP] Add shortened name value

### DIFF
--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -5,6 +5,7 @@ import jmespath
 
 from profiles.models import Address, Affiliation, Date, Name, Profile
 from profiles.orcid import VISIBILITY_PUBLIC
+from profiles.utilities import shorten_name
 
 
 def update_profile_from_orcid_record(profile: Profile, orcid_record: dict) -> None:
@@ -28,11 +29,12 @@ def _update_name_from_orcid_record(profile: Profile, orcid_record: dict) -> None
 
     if given_name and family_name:
         profile.name = Name('{} {}'.format(given_name, family_name),
-                            '{}, {}'.format(family_name, given_name))
+                            '{}, {}'.format(family_name, given_name),
+                            shorten_name(given_name, family_name))
     elif given_name:
-        profile.name = Name(given_name, given_name)
+        profile.name = Name(given_name, given_name, given_name)
     elif family_name:
-        profile.name = Name(family_name, family_name)
+        profile.name = Name(family_name, family_name, family_name)
 
 
 def _update_affiliations_from_orcid_record(profile: Profile, orcid_record: dict) -> None:

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -91,12 +91,13 @@ class OrcidToken(db.Model):
 
 
 class Name(object):
-    def __init__(self, preferred: str, index: str = None) -> None:
+    def __init__(self, preferred: str, index: str = None, shortened: str = None) -> None:
         if index is None:
             index = guess_index_name(preferred)
 
         self.preferred = preferred
         self.index = index
+        self.shortened = shortened or preferred
 
     def __composite_values__(self) -> Iterable[str]:
         return self.preferred, self.index

--- a/profiles/serializer/normalizer.py
+++ b/profiles/serializer/normalizer.py
@@ -74,4 +74,5 @@ def normalize_name(name: Name) -> dict:
     return {
         'preferred': name.preferred,
         'index': name.index,
+        'shortened': name.shortened
     }

--- a/profiles/utilities.py
+++ b/profiles/utilities.py
@@ -62,6 +62,19 @@ def remove_none_values(items: dict) -> dict:
     return dict(filter(lambda item: item[1] is not None, items.items()))
 
 
+def shorten_name(given_names: str, family_name: str) -> str:
+    """Provide basic shortened name from full name values
+
+    >>> shorten_name('Francisco', 'Baños')
+    'F. Baños'
+
+    :param given_names: str
+    :param family_name: str
+    :return: str
+    """
+    return '{0}. {1}'.format(given_names.split()[0][0], family_name)
+
+
 def validate_json(data: dict, schema_name: str, schema_dir: str = ''):
     # option to provide a schema_dir allows dummy_schema to be found for tests,
     # this whole function will be removed and replaced with

--- a/test/serializer/test_normalize.py
+++ b/test/serializer/test_normalize.py
@@ -21,7 +21,8 @@ def test_it_normalizes_profiles(id_, preferred, index):
         'id': id_,
         'name': {
             'preferred': preferred,
-            'index': index
+            'index': index,
+            'shortened': preferred
         },
         'emailAddresses': [],
         'affiliations': []
@@ -36,6 +37,7 @@ def test_it_normalizes_profile_with_orcid():
         'name': {
             'preferred': 'Foo Bar',
             'index': 'Bar, Foo',
+            'shortened': 'Foo Bar'
         },
         'emailAddresses': [],
         'affiliations': [],
@@ -91,6 +93,7 @@ def test_it_normalizes_profile_with_an_affiliation(yesterday):
         'name': {
             'preferred': 'Foo Bar',
             'index': 'Bar, Foo',
+            'shortened': 'Foo Bar'
         },
         'emailAddresses': [],
         'affiliations': [
@@ -141,6 +144,7 @@ def test_it_normalizes_profile_with_affiliations(yesterday):
         'name': {
             'preferred': 'Foo Bar',
             'index': 'Bar, Foo',
+            'shortened': 'Foo Bar'
         },
         'emailAddresses': [],
         'affiliations': [

--- a/test/serializer/test_normalize_snippet.py
+++ b/test/serializer/test_normalize_snippet.py
@@ -19,7 +19,8 @@ def test_it_normalizes_profile_snippets(id_, preferred, index, orcid):
         'id': id_,
         'name': {
             'preferred': preferred,
-            'index': index
+            'index': index,
+            'shortened': preferred
         },
     }
 
@@ -30,6 +31,7 @@ def test_it_normalizes_profile_snippets(id_, preferred, index, orcid):
         'name': {
             'preferred': preferred,
             'index': index,
+            'shortened': preferred
         },
         'orcid': orcid,
     }

--- a/test/utilities/test_shorten_name.py
+++ b/test/utilities/test_shorten_name.py
@@ -1,0 +1,43 @@
+import pytest
+
+from profiles.utilities import shorten_name
+
+name_fixtures = (
+    {'given': 'Francisco', 'family': 'Baños', 'short': 'F. Baños'},
+    {'given': 'Verónica', 'family': 'López López', 'short': 'V. López López'},
+    {'given': 'Татьяна', 'family': 'Яковлева', 'short': 'Т. Яковлева'},
+    {'given': '璞玉', 'family': '田', 'short': '璞. 田'},
+    {'given': 'jian', 'family': 'yilang', 'short': 'j. yilang'},
+    # {'given': 'السيد محمد', 'family': 'وردة أحمد', 'short': 'وردة أحمد .د'},
+    {
+        'given': 'Francisco Javier',
+        'family': 'Cuevas-de-la-Rosa',
+        'short': 'F. Cuevas-de-la-Rosa'
+    },
+    {
+        'given': 'MARIA ISABEL',
+        'family': 'GONZALEZ SANCHEZ',
+        'short': 'M. GONZALEZ SANCHEZ'
+    },
+    {
+        'given': 'Patrícia Andreia Pimenta de Castro',
+        'family': 'Martins',
+        'short': 'P. Martins'
+    },
+    {
+        'given': 'Luis J',
+        'family': 'Fernández-Clemente Martín-Orozco',
+        'short': 'L. Fernández-Clemente Martín-Orozco'
+    },
+    {
+        'given': 'Alexandra',
+        'family': 'Imaculada de Oliveira e Medeiros',
+        'short': 'A. Imaculada de Oliveira e Medeiros'
+    },
+)
+
+
+@pytest.mark.parametrize('name', name_fixtures)
+def test_it_can_shorten_name(name):
+    short_name = shorten_name(name['given'], name['family'])
+    assert short_name == name['short']


### PR DESCRIPTION
I have added a basic implementation to add a `shortened` value to the `Name` class.

If we are to extend this to be a bit more intelligent then I thought we could [detect the language](https://github.com/Mimino666/langdetect) then apply custom rules if required (e.g. for Arabic or Japanese) else use the standard transform. I played around with this and it seemed to work.