### PR TITLE
Catch any exception raised by an event handler

### DIFF
--- a/profiles/events.py
+++ b/profiles/events.py
@@ -11,6 +11,7 @@ from profiles.database import db
 from profiles.exceptions import UpdateEventFailure
 from profiles.models import Affiliation, EmailAddress, Profile
 from profiles.orcid import OrcidClient
+from profiles.utilities import catch_exceptions
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ OPERATION_UPDATE = 'update'
 def maintain_orcid_webhook(orcid: Dict[str, str], orcid_client: OrcidClient,
                            uri_signer: URLSafeSerializer) -> Callable[..., None]:
     # pylint:disable=unused-argument
+    @catch_exceptions(LOGGER)
     def webhook_maintainer(sender: Any, changes: List[Tuple[db.Model, str]]) -> None:
         profiles = [x for x in changes if isinstance(x[0], Profile) and x[0].orcid]
 
@@ -47,6 +49,7 @@ def maintain_orcid_webhook(orcid: Dict[str, str], orcid_client: OrcidClient,
 
 def send_update_events(publisher: EventPublisher) -> Callable[..., None]:
     # pylint:disable=unused-argument
+    @catch_exceptions(LOGGER)
     def event_handler(sender: Any, changes: List[Tuple[db.Model, str]]) -> None:
         ids = []
 

--- a/profiles/utilities.py
+++ b/profiles/utilities.py
@@ -4,7 +4,8 @@ import random
 import string
 from datetime import datetime
 from functools import wraps
-from typing import Callable
+from logging import Logger
+from typing import Any, Callable
 
 from elife_api_validator import SCHEMA_DIRECTORY
 from flask import request
@@ -13,6 +14,20 @@ import pendulum
 from werkzeug.wrappers import Response
 
 from profiles.exceptions import SchemaNotFound
+
+
+def catch_exceptions(logger: Logger) -> Callable[..., Any]:
+    def outer_wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except BaseException as exception:
+                logger.exception(exception)
+
+        return wrapper
+
+    return outer_wrapper
 
 
 def cache(allow_revalidation: bool = True) -> Callable[..., Response]:

--- a/profiles/utilities.py
+++ b/profiles/utilities.py
@@ -22,7 +22,7 @@ def catch_exceptions(logger: Logger) -> Callable[..., Any]:
         def wrapper(*args, **kwargs) -> Any:
             try:
                 return func(*args, **kwargs)
-            except BaseException as exception:
+            except Exception as exception:  # pylint: disable=broad-except
                 logger.exception(exception)
 
         return wrapper

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 from _pytest.fixtures import FixtureRequest
 from flask import Flask
 from flask.testing import FlaskClient
-from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy, models_committed
 from hypothesis import settings as hyp_settings
 from hypothesis.configuration import set_hypothesis_home_dir
 from itsdangerous import URLSafeSerializer
@@ -162,6 +162,17 @@ def orcid_token() -> OrcidToken:
 @fixture
 def orcid_tokens() -> SQLAlchemyOrcidTokens:
     return SQLAlchemyOrcidTokens(db)
+
+
+@fixture
+def registered_handler_names():
+    handler_names = []
+    for id_, recv in models_committed.receivers.items():  # pylint:disable=unused-variable
+        try:
+            handler_names.append(recv.__name__)
+        except AttributeError:
+            pass
+    return handler_names
 
 
 @fixture()

--- a/test/events/test_maintain_orcid_webhook.py
+++ b/test/events/test_maintain_orcid_webhook.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 from unittest.mock import MagicMock, patch
 
 from flask_sqlalchemy import models_committed
@@ -90,6 +90,5 @@ def test_it_ignores_other_models_being_committed(orcid_token: OrcidToken,
     assert mock_orcid_client.remove_webhook.call_count == 0
 
 
-def test_it_has_a_valid_signal_handler_registered_on_app():
-    registered_handler_names = [recv.__name__ for id_, recv in models_committed.receivers.items()]
+def test_it_has_a_valid_signal_handler_registered_on_app(registered_handler_names: List[str]):
     assert 'webhook_maintainer' in registered_handler_names

--- a/test/events/test_maintain_orcid_webhook.py
+++ b/test/events/test_maintain_orcid_webhook.py
@@ -62,8 +62,8 @@ def test_it_will_remove_the_webhook_when_a_profile_is_deleted(profile: Profile,
                                                               orcid_config: Dict[str, str],
                                                               mock_orcid_client: MagicMock,
                                                               session: scoped_session,
-                                                              url_safe_serializer:
-                                                              URLSafeSerializer):
+                                                              url_safe_serializer: URLSafeSerializer
+                                                              ):
     session.add(profile)
     with patch('profiles.orcid.request'):
         session.commit()
@@ -97,13 +97,12 @@ def test_it_ignores_other_models_being_committed(orcid_token: OrcidToken,
 
 
 @patch('profiles.events.catch_exceptions')
-def test_exception_not_handled_if_catch_decorator_is_removed(mock_catch: MagicMock,
-                                                             profile: Profile,
+def test_exception_not_handled_if_catch_decorator_is_removed(profile: Profile,
                                                              orcid_config: Dict[str, str],
                                                              mock_orcid_client: MagicMock,
                                                              session: scoped_session,
-                                                             url_safe_serializer:
-                                                             URLSafeSerializer):
+                                                             url_safe_serializer: URLSafeSerializer
+                                                             ):
     with pytest.raises(Exception):
         mock_orcid_client.remove_webhook.side_effect = Exception('Some Exception')
 
@@ -126,8 +125,8 @@ def test_exception_is_handled_by_catch_exception_decorator(profile: Profile,
                                                            orcid_config: Dict[str, str],
                                                            mock_orcid_client: MagicMock,
                                                            session: scoped_session,
-                                                           url_safe_serializer:
-                                                           URLSafeSerializer):
+                                                           url_safe_serializer: URLSafeSerializer
+                                                           ):
     mock_orcid_client.remove_webhook.side_effect = Exception('Some Exception')
 
     session.add(profile)

--- a/test/events/test_maintain_orcid_webhook.py
+++ b/test/events/test_maintain_orcid_webhook.py
@@ -94,29 +94,6 @@ def test_it_ignores_other_models_being_committed(orcid_token: OrcidToken,
     assert mock_orcid_client.remove_webhook.call_count == 0
 
 
-@patch('profiles.events.catch_exceptions')
-def test_exception_not_handled_if_catch_decorator_is_removed(profile: Profile,
-                                                             orcid_config: Dict[str, str],
-                                                             mock_orcid_client: MagicMock,
-                                                             session: scoped_session,
-                                                             url_safe_serializer: URLSafeSerializer,
-                                                             commit: Callable[[], None]):
-    with pytest.raises(Exception):
-        mock_orcid_client.remove_webhook.side_effect = Exception('Some Exception')
-
-        session.add(profile)
-        commit()
-
-        webhook_maintainer = maintain_orcid_webhook(orcid_config, mock_orcid_client,
-                                                    url_safe_serializer)
-        models_committed.connect(receiver=webhook_maintainer)
-
-        session.delete(profile)
-        commit()
-
-        assert mock_orcid_client.remove_webhook.call_count == 1
-
-
 def test_exception_is_handled_by_catch_exception_decorator(profile: Profile,
                                                            orcid_config: Dict[str, str],
                                                            mock_orcid_client: MagicMock,

--- a/test/events/test_maintain_orcid_webhook.py
+++ b/test/events/test_maintain_orcid_webhook.py
@@ -3,10 +3,15 @@ from unittest.mock import MagicMock, patch
 
 from flask_sqlalchemy import models_committed
 from itsdangerous import URLSafeSerializer
+import pytest
 from sqlalchemy.orm import scoped_session
 
 from profiles.events import maintain_orcid_webhook
 from profiles.models import OrcidToken, Profile
+
+
+def test_it_has_a_valid_signal_handler_registered_on_app(registered_handler_names: List[str]):
+    assert 'webhook_maintainer' in registered_handler_names
 
 
 def test_it_sets_a_webhook_when_a_profile_is_inserted(profile: Profile,
@@ -63,6 +68,7 @@ def test_it_will_remove_the_webhook_when_a_profile_is_deleted(profile: Profile,
     with patch('profiles.orcid.request'):
         session.commit()
 
+    mock_orcid_client.remove_webhook.side_effect = Exception('Some Exception')
     webhook_maintainer = maintain_orcid_webhook(orcid_config, mock_orcid_client,
                                                 url_safe_serializer)
     models_committed.connect(receiver=webhook_maintainer)
@@ -90,5 +96,50 @@ def test_it_ignores_other_models_being_committed(orcid_token: OrcidToken,
     assert mock_orcid_client.remove_webhook.call_count == 0
 
 
-def test_it_has_a_valid_signal_handler_registered_on_app(registered_handler_names: List[str]):
-    assert 'webhook_maintainer' in registered_handler_names
+@patch('profiles.events.catch_exceptions')
+def test_exception_not_handled_if_catch_decorator_is_removed(mock_catch: MagicMock,
+                                                             profile: Profile,
+                                                             orcid_config: Dict[str, str],
+                                                             mock_orcid_client: MagicMock,
+                                                             session: scoped_session,
+                                                             url_safe_serializer:
+                                                             URLSafeSerializer):
+    with pytest.raises(Exception):
+        mock_orcid_client.remove_webhook.side_effect = Exception('Some Exception')
+
+        session.add(profile)
+        with patch('profiles.orcid.request'):
+            session.commit()
+
+        webhook_maintainer = maintain_orcid_webhook(orcid_config, mock_orcid_client,
+                                                    url_safe_serializer)
+        models_committed.connect(receiver=webhook_maintainer)
+
+        session.delete(profile)
+        with patch('profiles.orcid.request'):
+            session.commit()
+
+        assert mock_orcid_client.remove_webhook.call_count == 1
+
+
+def test_exception_is_handled_by_catch_exception_decorator(profile: Profile,
+                                                           orcid_config: Dict[str, str],
+                                                           mock_orcid_client: MagicMock,
+                                                           session: scoped_session,
+                                                           url_safe_serializer:
+                                                           URLSafeSerializer):
+    mock_orcid_client.remove_webhook.side_effect = Exception('Some Exception')
+
+    session.add(profile)
+    with patch('profiles.orcid.request'):
+        session.commit()
+
+    webhook_maintainer = maintain_orcid_webhook(orcid_config, mock_orcid_client,
+                                                url_safe_serializer)
+    models_committed.connect(receiver=webhook_maintainer)
+
+    session.delete(profile)
+    with patch('profiles.orcid.request'):
+        session.commit()
+
+    assert mock_orcid_client.remove_webhook.call_count == 1

--- a/test/events/test_maintain_orcid_webhook.py
+++ b/test/events/test_maintain_orcid_webhook.py
@@ -1,9 +1,8 @@
 from typing import Callable, Dict, List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from flask_sqlalchemy import models_committed
 from itsdangerous import URLSafeSerializer
-import pytest
 from sqlalchemy.orm import scoped_session
 
 from profiles.events import maintain_orcid_webhook

--- a/test/events/test_send_update_events.py
+++ b/test/events/test_send_update_events.py
@@ -86,27 +86,6 @@ def test_it_only_sends_one_event_if_multiple_changes_are_detected(mock_publisher
     assert mock_publisher.publish.call_args[0][0] == {'id': '12345678', 'type': 'profile'}
 
 
-@patch('profiles.events.catch_exceptions')
-def test_exception_not_handled_if_catch_decorator_is_removed(mock_catch: MagicMock,
-                                                             mock_publisher: MagicMock,
-                                                             profile: Profile,
-                                                             session: scoped_session,
-                                                             commit: Callable[[], None]) -> None:
-    with pytest.raises(Exception):
-        mock_publisher.publish.side_effect = Exception('Some Exception')
-
-        event_publisher = send_update_events(publisher=mock_publisher)
-        models_committed.connect(receiver=event_publisher)
-
-        affiliation = Affiliation('1', Address(countries.get('gb'), 'City'),
-                                  'Organisation', Date(2017))
-
-        profile.add_affiliation(affiliation)
-        session.add(profile)
-
-        commit()
-
-
 def test_exception_is_handled_by_catch_exception_decorator(mock_publisher: MagicMock,
                                                            profile: Profile,
                                                            session: scoped_session,

--- a/test/events/test_send_update_events.py
+++ b/test/events/test_send_update_events.py
@@ -1,9 +1,8 @@
 from typing import Callable, List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from flask_sqlalchemy import models_committed
 from iso3166 import countries
-import pytest
 from sqlalchemy.orm import scoped_session
 
 from profiles.events import send_update_events

--- a/test/events/test_send_update_events.py
+++ b/test/events/test_send_update_events.py
@@ -1,3 +1,4 @@
+from typing import List
 from unittest.mock import MagicMock, patch
 
 from flask_sqlalchemy import models_committed
@@ -13,8 +14,7 @@ from profiles.models import (
 )
 
 
-def test_it_has_a_valid_signal_handler_registered_on_app():
-    registered_handler_names = [recv.__name__ for id_, recv in models_committed.receivers.items()]
+def test_it_has_a_valid_signal_handler_registered_on_app(registered_handler_names: List[str]):
     assert 'event_handler' in registered_handler_names
 
 

--- a/test/utilities/test_catch_exceptions.py
+++ b/test/utilities/test_catch_exceptions.py
@@ -1,0 +1,43 @@
+import logging
+from logging import Handler, Logger, Manager
+from logging.handlers import BufferingHandler
+
+from pytest import fixture
+
+from profiles.utilities import catch_exceptions
+
+
+@fixture
+def logger(handler: Handler) -> Logger:
+    logger = Logger('logger', logging.DEBUG)
+    logger.addHandler(handler)
+    logger.manager = Manager('root')
+
+    return logger
+
+
+@fixture
+def handler() -> Handler:
+    return BufferingHandler(100)
+
+
+def test_it_catches_and_logs_exceptions(logger: Logger, handler: BufferingHandler):
+    @catch_exceptions(logger)
+    def my_function():
+        raise Exception('My exception')
+
+    result = my_function()
+
+    assert result is None
+    assert len(handler.buffer) == 1
+
+
+def test_it_does_nothing_when_no_exception(logger: Logger, handler: BufferingHandler):
+    @catch_exceptions(logger)
+    def my_function():
+        return True
+
+    result = my_function()
+
+    assert result is True
+    assert len(handler.buffer) == 0


### PR DESCRIPTION
Bad things seem to happen if an event handler raises any exception, it gets disconnected and the database transaction doesn't complete, requiring a restart.