### PR TITLE
Handle missing affiliation start dates

### DIFF
--- a/migrations/versions/d4f16fce7228_.py
+++ b/migrations/versions/d4f16fce7228_.py
@@ -1,0 +1,25 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd4f16fce7228'
+down_revision = '6e06221b94fa'
+branch_labels = None
+depends_on = None
+
+affiliation_helper = sa.Table(
+    'affiliation',
+    sa.MetaData(),
+    sa.Column('starts_year', sa.Integer()),
+)
+
+
+def upgrade():
+    op.alter_column('affiliation', 'starts_year', nullable=True)
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    connection.execute(affiliation_helper.delete().where(affiliation_helper.c.starts_year == None))
+
+    op.alter_column('affiliation', 'starts_year', nullable=False)

--- a/profiles/commands.py
+++ b/profiles/commands.py
@@ -53,7 +53,7 @@ def _update_affiliations_from_orcid_record(profile: Profile, orcid_record: dict)
                 region=address.get('region'),
                 country=countries.get(address['country']),
             ),
-            starts=_convert_orcid_date(orcid_affiliation['start-date']),
+            starts=_convert_orcid_date(orcid_affiliation.get('start-date') or {}),
             ends=_convert_orcid_date(orcid_affiliation.get('end-date') or {}),
             restricted=orcid_affiliation['visibility'] != VISIBILITY_PUBLIC,
         )

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -147,7 +147,7 @@ class Affiliation(db.Model):
     _region = db.Column(db.Text(), name='region')
     _country = db.Column(ISO3166Country, name='country', nullable=False)
     _starts = composite(Date, '_starts_year', '_starts_month', '_starts_day')
-    _starts_year = db.Column(db.Integer(), name='starts_year', nullable=False)
+    _starts_year = db.Column(db.Integer(), name='starts_year')
     _starts_month = db.Column(db.Integer(), name='starts_month')
     _starts_day = db.Column(db.Integer(), name='starts_day')
     _ends = composite(Date, '_ends_year', '_ends_month', '_ends_day')

--- a/test/commands/test_update_profile_from_orcid_record.py
+++ b/test/commands/test_update_profile_from_orcid_record.py
@@ -151,12 +151,16 @@ def test_it_adds_affiliations_with_a_partial_start_dates():
              'organization': {'name': 'Organisation 2',
                               'address': {'city': 'City 2', 'region': 'Region 2', 'country': 'US'}},
              'visibility': 'LIMIT'},
+            {'put-code': 3, 'start-date': None,
+             'organization': {'name': 'Organisation 2',
+                              'address': {'city': 'City 2', 'region': 'Region 2', 'country': 'US'}},
+             'visibility': 'LIMIT'},
         ]},
     }}
 
     update_profile_from_orcid_record(profile, orcid_record)
 
-    assert len(profile.affiliations) == 2
+    assert len(profile.affiliations) == 3
 
     assert profile.affiliations[0].id == '1'
     assert profile.affiliations[0].restricted is False
@@ -167,6 +171,11 @@ def test_it_adds_affiliations_with_a_partial_start_dates():
     assert profile.affiliations[1].restricted is True
     assert profile.affiliations[1].position == 1
     assert profile.affiliations[1].starts == Date(2015, 12)
+
+    assert profile.affiliations[2].id == '3'
+    assert profile.affiliations[2].restricted is True
+    assert profile.affiliations[2].position == 2
+    assert profile.affiliations[2].starts is None
 
 
 def test_it_adds_affiliations_with_a_partial_end_dates():

--- a/test/models/test_affiliation.py
+++ b/test/models/test_affiliation.py
@@ -60,6 +60,13 @@ def test_it_may_be_restricted():
     assert has_not.restricted is False
 
 
+def test_it_can_detect_if_current_without_start_date():
+    address = Address(countries.get('gb'), 'City')
+    affiliation = Affiliation('1', address=address, organisation='Org')
+
+    assert affiliation.is_current() is True
+
+
 def test_it_can_detect_if_current_without_ends_date(yesterday):
     address = Address(countries.get('gb'), 'City')
     affiliation = Affiliation('1', address=address, organisation='Org', starts=yesterday)
@@ -86,5 +93,12 @@ def test_it_can_detect_if_not_current_with_past_starts_date_and_past_ends_date(y
     address = Address(countries.get('gb'), 'City')
     affiliation = Affiliation('1', address=address, organisation='Org',
                               starts=yesterday, ends=yesterday)
+
+    assert affiliation.is_current() is False
+
+
+def test_it_can_detect_if_not_current_with_no_starts_date_and_past_ends_date(yesterday):
+    address = Address(countries.get('gb'), 'City')
+    affiliation = Affiliation('1', address=address, organisation='Org', ends=yesterday)
 
     assert affiliation.is_current() is False


### PR DESCRIPTION
While looking through the logs I saw that there's errors when missing an affiliation start date (@NickDuf's profile). Looking at the XSD for the API, it's possible for it to be missing. However, through the ORCID UI it's a required field, so this might be for legacy data.

This should handle it correctly.