### PR TITLE
Add proofreader

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,3 +7,4 @@ ignored-classes = responses,scoped_session,SQLAlchemy
 good-names = db,id
 function-rgx = [a-z_][a-z0-9_]{2,60}$
 method-rgx = [a-z_][a-z0-9_]{2,60}$
+reports = n

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -3,6 +3,7 @@ set -e
 
 source venv/bin/activate
 
-pylint --reports=n manage.py profiles/ test/*.py
-flake8 manage.py profiles/ test/
+pip install proofreader==0.0.2
+
+python -m proofreader manage.py profiles/ test/
 python -m pytest --junitxml=build/pytest.xml


### PR DESCRIPTION
This replaces the calls to `flake8` and `pylint` with `proofreader`. As this project currently has its own overrides the default configurations will be overridden. 

This means functionally nothing has changed but it brings the project closer in line with how other current and future Python-based projects are to be structured, at least in terms of linting and pre-test checks.