### PR TITLE
Add test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = profiles

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 eLife Profiles
 ==============
 
-[![Build Status](https://ci--alfred.elifesciences.org/buildStatus/icon?job=test-profiles)](https://ci--alfred.elifesciences.org/job/test-profiles/)
+[![Build Status](https://ci--alfred.elifesciences.org/buildStatus/icon?job=test-profiles)](https://ci--alfred.elifesciences.org/job/test-profiles/) [![Coverage Status](https://coveralls.io/repos/github/elifesciences/profiles/badge.svg?branch=develop)](https://coveralls.io/github/elifesciences/profiles?branch=develop)
 
 Dependencies
 ------------

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -3,7 +3,10 @@ set -e
 
 source venv/bin/activate
 
+pip install coveralls
 pip install proofreader==0.0.2
 
 python -m proofreader manage.py profiles/ test/
-python -m pytest --junitxml=build/pytest.xml
+coverage run -m pytest --junitxml=build/pytest.xml
+
+COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/profiles) coveralls`

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -9,4 +9,4 @@ pip install proofreader==0.0.2
 python -m proofreader manage.py profiles/ test/
 coverage run -m pytest --junitxml=build/pytest.xml
 
-COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/profiles) coveralls`
+COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/profiles) coveralls


### PR DESCRIPTION
Added test coverage report generation and integration with [coveralls](https://coveralls.io/github/elifesciences/profiles).

I have disabled auto PR comments (so no spamming) and opted to not have this be an active check on PRs like we do in our libraries. This can be changed if need be in the repo settings and the failure percentage for a decrease can be configured in coveralls.