### PR TITLE
Add create profile cli command

### DIFF
--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -1,11 +1,13 @@
 import logging
 from abc import ABC
-from typing import Dict
+from typing import Dict, List
 
 from flask import url_for
-from flask_script import Command as BaseCommand
+from flask_script import Command as BaseCommand, Option
 from itsdangerous import URLSafeSerializer
 
+from profiles.exceptions import ProfileNotFound
+from profiles.models import Name, Profile
 from profiles.orcid import OrcidClient
 from profiles.repositories import Profiles
 from profiles.types import CanBeCleared
@@ -34,6 +36,44 @@ class ClearCommand(Command):
     def run(self) -> None:
         for each in self.repositories:
             each.clear()
+
+
+class CreateProfileCommand(Command):
+    """Allow manual creation of profiles from the commandline.
+
+    Example:
+
+    $ python manage.py create-profile --name "Test User" --email "test@test.com"
+
+    """
+    NAME = 'create-profile'
+
+    def __init__(self, profiles: Profiles):
+        super(CreateProfileCommand, self).__init__()
+        self.profiles = profiles
+
+    def get_options(self) -> List[Option]:
+        return [
+            Option('-e', '--email', dest='email'),
+            Option('-n', '--name', dest='name'),
+        ]
+
+    # pylint: disable=method-hidden,arguments-differ
+    def run(self, name, email) -> None:
+        # pylint is complaining about arguments differing from base class
+        # though this is the recommended way to define the option args in the
+        # run() definition...
+        if name and email:
+            try:
+                profile = self.profiles.get_by_email_address(email)
+            except ProfileNotFound:
+                profile = Profile(self.profiles.next_id(), Name(name.strip('"')))
+                self.profiles.add(profile)
+                profile.add_email_address(email=email, restricted=True)
+
+            return profile.id, email
+        else:
+            print('Error: Please provide valid strings for both `--name` and `--email`')
 
 
 class SetOrcidWebhooksCommand(Command):

--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -54,8 +54,8 @@ class CreateProfileCommand(Command):
 
     def get_options(self) -> List[Option]:
         return [
-            Option('-e', '--email', dest='email'),
-            Option('-n', '--name', dest='name'),
+            Option('-e', '--email', dest='email', type=str),
+            Option('-n', '--name', dest='name', type=str),
         ]
 
     # pylint: disable=method-hidden,arguments-differ
@@ -67,7 +67,7 @@ class CreateProfileCommand(Command):
             try:
                 profile = self.profiles.get_by_email_address(email)
             except ProfileNotFound:
-                profile = Profile(self.profiles.next_id(), Name(name.strip('"')))
+                profile = Profile(self.profiles.next_id(), Name(name))
                 self.profiles.add(profile)
                 profile.add_email_address(email=email, restricted=True)
 

--- a/profiles/factory.py
+++ b/profiles/factory.py
@@ -7,7 +7,7 @@ from flask_sqlalchemy import models_committed
 from itsdangerous import URLSafeSerializer
 
 from profiles.api import api, errors, oauth2, ping, webhook
-from profiles.cli import ClearCommand, SetOrcidWebhooksCommand
+from profiles.cli import ClearCommand, CreateProfileCommand, SetOrcidWebhooksCommand
 from profiles.clients import Clients
 from profiles.config import Config
 from profiles.events import maintain_orcid_webhook, send_update_events
@@ -41,6 +41,7 @@ def create_app(config: Config, clients: Clients) -> Flask:
                                                            'env': config.name})
     app.commands = [
         ClearCommand(orcid_tokens, profiles),
+        CreateProfileCommand(profiles),
         SetOrcidWebhooksCommand(profiles, config.orcid, orcid_client, uri_signer)
     ]
 

--- a/test/cli/test_create_profile_command.py
+++ b/test/cli/test_create_profile_command.py
@@ -1,0 +1,18 @@
+from profiles.cli import CreateProfileCommand
+from profiles.repositories import SQLAlchemyProfiles
+
+
+def test_can_create_profile_via_command(profiles: SQLAlchemyProfiles) -> None:
+    cmd = CreateProfileCommand(profiles=profiles)
+    cmd.run('Test User', 'test@test.com')
+
+    assert profiles.get_by_email_address('test@test.com')
+
+
+def test_can_run_command_multiple_times(profiles: SQLAlchemyProfiles) -> None:
+    cmd = CreateProfileCommand(profiles=profiles)
+
+    for _ in range(5):
+        cmd.run('Test User', 'test@test.com')
+
+    assert len(profiles.list()) == 1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,7 +19,7 @@ from profiles.config import DevConfig
 from profiles.factory import create_app
 from profiles.models import Date, Name, OrcidToken, Profile, db
 from profiles.orcid import OrcidClient
-from profiles.repositories import SQLAlchemyOrcidTokens
+from profiles.repositories import SQLAlchemyOrcidTokens, SQLAlchemyProfiles
 from profiles.utilities import expires_at
 
 BUILD_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + '/build/'
@@ -162,6 +162,11 @@ def orcid_token() -> OrcidToken:
 @fixture
 def orcid_tokens() -> SQLAlchemyOrcidTokens:
     return SQLAlchemyOrcidTokens(db)
+
+
+@fixture
+def profiles() -> SQLAlchemyProfiles:
+    return SQLAlchemyProfiles(db)
 
 
 @fixture


### PR DESCRIPTION
Primary use is for the ingestion of existing `{name: email}` pairs from other services.