### PR TITLE
Stop non-5xx responses being logged as errors

### DIFF
--- a/profiles/api/errors.py
+++ b/profiles/api/errors.py
@@ -33,7 +33,10 @@ def client_error_handler(exception: ClientError) -> Response:
 
 
 def http_error_handler(exception: HTTPException) -> Response:
-    LOGGER.exception(exception)
+    if exception.code < 500:
+        LOGGER.info(exception)
+    else:
+        LOGGER.exception(exception)
 
     return _handle_http_error(exception)
 


### PR DESCRIPTION
Don't know if this'll stop 400 responses from appearing in New Relic, but we seem to be logging them as `ERROR` level.