### PR TITLE
Removed ability to modify existing profile name through cli command

### DIFF
--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -66,7 +66,6 @@ class CreateProfileCommand(Command):
         if name and email:
             try:
                 profile = self.profiles.get_by_email_address(email)
-                profile.name = Name(name)
             except ProfileNotFound:
                 profile = Profile(self.profiles.next_id(), Name(name))
                 self.profiles.add(profile)


### PR DESCRIPTION
This is no longer needed and if required in the future can be implemented through a separate command so that `create-profile` does just what its name states.