### PR TITLE
Ci should build images using ci configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ elifePipeline {
         {
             stage 'Build images', {
                 checkout scm
-                sh "IMAGE_TAG=${commit} docker-compose build"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml build"
             }
 
             stage 'Project tests', {


### PR DESCRIPTION
We could always use this with an environment variable COMPOSE_FILE global to the server, but that would be *too* magic.