### PR TITLE
Add /profiles to smoke tests

### DIFF
--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -2,3 +2,4 @@
 set -ex
 
 [ $(curl --write-out %{http_code} --silent --output /dev/null localhost/ping) == 200 ]
+[ $(curl --write-out %{http_code} --silent --output /dev/null localhost/profiles) == 200 ]


### PR DESCRIPTION
It's a route that accesses the database, proving that the connection works