### PR TITLE
Enable threads

### DIFF
--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -17,3 +17,4 @@ max-requests=5000
 harakiri = 10
 # documented at https://docs.newrelic.com/docs/agents/python-agent/hosting-mechanisms/python-agent-uwsgi
 single-interpreter = True
+enable-threads = True


### PR DESCRIPTION
This is required by the New Relic agent. The agent is not running locally, but for consistency it's safer to use the same configuration everywhere