### PR TITLE
Automatically read web and db hosts in smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ elifePipeline {
                     sh "IMAGE_TAG=${commit} COVERALLS_REPO_TOKEN=\$(cat /etc/coveralls/tokens/profiles) docker-compose -f docker-compose.ci.yml run --name profiles_ci_project_tests ci ./project_tests.sh"
                     sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d"
                     sh "docker wait profiles_migrate_1"
-                    sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml exec -T wsgi ./smoke_tests_wsgi.sh profiles--dev"
+                    sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml exec -T wsgi ./smoke_tests_wsgi.sh"
                 } finally {
                     sh "docker cp profiles_ci_project_tests:/srv/profiles/build ."
                     step([$class: "JUnitResultArchiver", testResults: 'build/*.xml'])

--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -20,8 +20,8 @@ class Command(ABC, BaseCommand):
         with app.app_context():
             return self.run(*args, **kwargs)
 
-"Allows calling a method on the Config object to print its result"
 class ReadConfiguration(Command):
+    "Allows calling a method on the Config object to print its result"
     NAME = 'read-configuration'
 
     def __init__(self, config) -> None:

--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -33,7 +33,7 @@ class ReadConfiguration(Command):
             Option('-s', '--method', dest='method', type=str),
         ]
 
-    # pylint: disable=method-hidden
+    # pylint: disable=method-hidden,arguments-differ
     def run(self, method) -> None:
         if method:
             print(getattr(self.config, method)())

--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -20,6 +20,26 @@ class Command(ABC, BaseCommand):
         with app.app_context():
             return self.run(*args, **kwargs)
 
+"Allows calling a method on the Config object to print its result"
+class ReadConfiguration(Command):
+    NAME = 'read-configuration'
+
+    def __init__(self, config) -> None:
+        super(ReadConfiguration, self).__init__()
+        self.config = config
+
+    def get_options(self) -> List[Option]:
+        return [
+            Option('-s', '--method', dest='method', type=str),
+        ]
+
+    # pylint: disable=method-hidden
+    def run(self, method) -> None:
+        if method:
+            print(getattr(self.config, method)())
+        else:
+            print("Error: Please provide a valid --method to call")
+
 
 class ClearCommand(Command):
     NAME = 'clear'
@@ -28,10 +48,6 @@ class ClearCommand(Command):
         super(ClearCommand, self).__init__()
         self.repositories = repositories
 
-    # weird decoration made by the superclass that wraps this method
-    # not going to lose sleep over this for now,
-    # let's see whether we get more commands
-    # and we keep flask_script in the long term
     # pylint: disable=method-hidden
     def run(self) -> None:
         for each in self.repositories:

--- a/profiles/cli.py
+++ b/profiles/cli.py
@@ -20,6 +20,7 @@ class Command(ABC, BaseCommand):
         with app.app_context():
             return self.run(*args, **kwargs)
 
+
 class ReadConfiguration(Command):
     "Allows calling a method on the Config object to print its result"
     NAME = 'read-configuration'

--- a/profiles/config.py
+++ b/profiles/config.py
@@ -23,6 +23,16 @@ class Config(ABC):
         self.SERVER_NAME = server_name
         self.PREFERRED_URL_SCHEME = scheme
 
+    def db_host(self):
+        m = re.match('.*@(.*)/.*', self.SQLALCHEMY_DATABASE_URI)
+        if m:
+            return m.group(1)
+        else:
+            raise RuntimeError
+
+    def web_host(self):
+        return self.SERVER_NAME
+
 
 class DevConfig(Config):
     DEBUG = True

--- a/profiles/factory.py
+++ b/profiles/factory.py
@@ -7,7 +7,12 @@ from flask_sqlalchemy import models_committed
 from itsdangerous import URLSafeSerializer
 
 from profiles.api import api, errors, oauth2, ping, webhook
-from profiles.cli import ClearCommand, CreateProfileCommand, ReadConfiguration, SetOrcidWebhooksCommand
+from profiles.cli import (
+    ClearCommand,
+    CreateProfileCommand,
+    ReadConfiguration,
+    SetOrcidWebhooksCommand
+)
 from profiles.clients import Clients
 from profiles.config import Config
 from profiles.events import maintain_orcid_webhook, send_update_events

--- a/profiles/factory.py
+++ b/profiles/factory.py
@@ -7,7 +7,7 @@ from flask_sqlalchemy import models_committed
 from itsdangerous import URLSafeSerializer
 
 from profiles.api import api, errors, oauth2, ping, webhook
-from profiles.cli import ClearCommand, CreateProfileCommand, SetOrcidWebhooksCommand
+from profiles.cli import ClearCommand, CreateProfileCommand, ReadConfiguration, SetOrcidWebhooksCommand
 from profiles.clients import Clients
 from profiles.config import Config
 from profiles.events import maintain_orcid_webhook, send_update_events
@@ -41,6 +41,7 @@ def create_app(config: Config, clients: Clients) -> Flask:
     app.commands = [
         ClearCommand(orcid_tokens, profiles),
         CreateProfileCommand(profiles),
+        ReadConfiguration(config),
         SetOrcidWebhooksCommand(profiles, config.orcid, orcid_client, uri_signer)
     ]
 

--- a/smoke_tests_wsgi.sh
+++ b/smoke_tests_wsgi.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
-host=${1:-profiles}
-db=${2:-db}
+host=$(venv/bin/python manage.py read-configuration --method web_host)
+db=$(venv/bin/python manage.py read-configuration --method db_host)
 
 wait_for_port 5432 15 "${db}"
 uwsgi_curl 127.0.0.1:9000 "${host}/ping"

--- a/smoke_tests_wsgi.sh
+++ b/smoke_tests_wsgi.sh
@@ -2,8 +2,9 @@
 set -ex
 
 host=${1:-profiles}
+db=${2:-db}
 
-wait_for_port 5432 15 db
+wait_for_port 5432 15 "${db}"
 uwsgi_curl 127.0.0.1:9000 "${host}/ping"
 uwsgi_curl 127.0.0.1:9000 "${host}/profiles"
 if [ "$ENVIRONMENT_NAME" = 'dev' ]; then


### PR DESCRIPTION
Started out to make them configurable, but it was more foolproof to just read the configuration to keep smoke tests easy to run from any user or automated process.