### PR TITLE
ELPP-3393 Introduce redirect_uris in place of redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Running the tests
 -----------------
 
 ```
-docker-compose -f docker-compose.yml -f docker-compose.ci.yml build
-docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm ci venv/bin/pytest
+docker-compose run --rm ci venv/bin/pytest
 ```
 
 Running the site

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Running the tests
 -----------------
 
 ```
-docker-compose run --rm ci venv/bin/pytest
+docker-compose -f docker-compose.yml -f docker-compose.ci.yml build
+docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm ci venv/bin/pytest
 ```
 
 Running the site

--- a/clients.yaml.dist
+++ b/clients.yaml.dist
@@ -3,7 +3,5 @@ client-name:
   client_secret: client_secret
   redirect_uris:
     - http://www.example.com/check
-  # deprecated redirect_uri
-  redirect_uri: http://www.example.com/check
 
 # ...

--- a/clients.yaml.dist
+++ b/clients.yaml.dist
@@ -1,6 +1,9 @@
 client-name:
   client_id: client_id
   client_secret: client_secret
+  redirect_uris:
+    - http://www.example.com/check
+  # deprecated redirect_uri
   redirect_uri: http://www.example.com/check
 
 # ...

--- a/config/clients.yaml
+++ b/config/clients.yaml
@@ -3,5 +3,3 @@ client-name:
   client_secret: client_secret
   redirect_uris:
     - http://www.example.com/check
-  # deprecated redirect_uri
-  redirect_uri: http://www.example.com/check

--- a/config/clients.yaml
+++ b/config/clients.yaml
@@ -1,4 +1,7 @@
 client-name:
   client_id: client_id
   client_secret: client_secret
+  redirect_uris:
+    - http://www.example.com/check
+  # deprecated redirect_uri
   redirect_uri: http://www.example.com/check

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -38,4 +38,5 @@ services:
         environment:
             - COVERALLS_REPO_TOKEN
         depends_on:
+            - wsgi
             - venv-dev

--- a/manage.py
+++ b/manage.py
@@ -19,7 +19,9 @@ CONFIG_FILE.read('app.cfg')
 CLIENTS_DATA = yaml.load(open('clients.yaml')) or {}
 # remove deprecated configuration key
 for data in CLIENTS_DATA:
+    # upgrade deprecated `redirect_uri` to `redirect_uris`
     if 'redirect_uri' in CLIENTS_DATA[data]:
+        CLIENTS_DATA[data]['redirect_uris'] = [CLIENTS_DATA[data]['redirect_uri']]
         del CLIENTS_DATA[data]['redirect_uri']
 CLIENTS = Clients(*[Client(name, **CLIENTS_DATA[name]) for name in CLIENTS_DATA])
 

--- a/manage.py
+++ b/manage.py
@@ -17,6 +17,10 @@ CONFIG_FILE = configparser.ConfigParser()
 CONFIG_FILE.read('app.cfg')
 
 CLIENTS_DATA = yaml.load(open('clients.yaml')) or {}
+# remove deprecated configuration key
+for data in CLIENTS_DATA:
+    if 'redirect_uri' in data:
+        del data['redirect_uri']
 CLIENTS = Clients(*[Client(name, **CLIENTS_DATA[name]) for name in CLIENTS_DATA])
 
 CONFIG = create_app_config(CONFIG_FILE)

--- a/manage.py
+++ b/manage.py
@@ -19,8 +19,8 @@ CONFIG_FILE.read('app.cfg')
 CLIENTS_DATA = yaml.load(open('clients.yaml')) or {}
 # remove deprecated configuration key
 for data in CLIENTS_DATA:
-    if 'redirect_uri' in data:
-        del data['redirect_uri']
+    if 'redirect_uri' in CLIENTS_DATA[data]:
+        del CLIENTS_DATA[data]['redirect_uri']
 CLIENTS = Clients(*[Client(name, **CLIENTS_DATA[name]) for name in CLIENTS_DATA])
 
 CONFIG = create_app_config(CONFIG_FILE)

--- a/profiles/api/oauth2.py
+++ b/profiles/api/oauth2.py
@@ -38,7 +38,7 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
         except KeyError as exception:
             raise BadRequest('Invalid client_id') from exception
 
-        redirect_uri = request.args.get('redirect_uri', client.canonical_redirect_uri())
+        redirect_uri = request.args.get('redirect_uri', client.canonical_redirect_uri)
         if redirect_uri not in client.redirect_uris:
             raise BadRequest('Invalid redirect_uri')
 

--- a/profiles/api/oauth2.py
+++ b/profiles/api/oauth2.py
@@ -38,7 +38,7 @@ def create_blueprint(orcid: Dict[str, str], clients: Clients, profiles: Profiles
         except KeyError as exception:
             raise BadRequest('Invalid client_id') from exception
 
-        redirect_uri = request.args.get('redirect_uri', client.canonical_uri())
+        redirect_uri = request.args.get('redirect_uri', client.canonical_redirect_uri())
         if redirect_uri not in client.redirect_uris:
             raise BadRequest('Invalid redirect_uri')
 

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -9,6 +9,7 @@ class Client(object):
         self.client_secret = client_secret
         self.redirect_uris = redirect_uris
 
+    @property
     def canonical_redirect_uri(self):
         return self.redirect_uris[0]
 

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, List
 class Client(object):
     def __init__(self,
                  name: str,
-                 client_id: str, 
+                 client_id: str,
                  client_secret: str,
                  redirect_uris: List[str]) -> None:
         self.name = name
@@ -13,7 +13,7 @@ class Client(object):
         self.client_secret = client_secret
         if not redirect_uris:
             raise ValueError(
-                "redirect_uris must provide at least one value to use as canonical: %s" \
+                "redirect_uris must provide at least one value to use as canonical: %s"
                 % redirect_uris
             )
         self.redirect_uris = redirect_uris

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -3,11 +3,15 @@ from typing import Any, Iterable
 
 
 class Client(object):
-    def __init__(self, name: str, client_id: str, client_secret: str, redirect_uri: str) -> None:
+    def __init__(self, name: str, client_id: str, client_secret: str, redirect_uris: list) -> None:
         self.name = name
         self.client_id = client_id
         self.client_secret = client_secret
-        self.redirect_uri = redirect_uri
+        self.redirect_uris = redirect_uris
+        self.redirect_uri = redirect_uris[0]
+
+    def canonical_redirect_uri(self):
+        return self.redirect_uris[0]
 
     def __repr__(self) -> str:
         return '<Client %r>' % self.name

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -8,7 +8,6 @@ class Client(object):
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uris = redirect_uris
-        self.redirect_uri = redirect_uris[0]
 
     def canonical_redirect_uri(self):
         return self.redirect_uris[0]

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -3,14 +3,14 @@ from typing import Any, Iterable
 
 
 class Client(object):
-    def __init__(self, name: str, client_id: str, client_secret: str, redirect_uris: list) -> None:
+    def __init__(self, name: str, client_id: str, client_secret: str, redirect_uris: List[str]) -> None:
         self.name = name
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uris = redirect_uris
 
     @property
-    def canonical_redirect_uri(self):
+    def canonical_redirect_uri(self) -> str:
         return self.redirect_uris[0]
 
     def __repr__(self) -> str:

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -1,14 +1,21 @@
 import collections
-from typing import Any, Iterable
+from typing import Any, Iterable, List
 
 
 class Client(object):
-    def __init__(self, name: str, client_id: str, client_secret: str, redirect_uris: List[str]) -> None:
+    def __init__(self,
+                 name: str,
+                 client_id: str, 
+                 client_secret: str,
+                 redirect_uris: List[str]) -> None:
         self.name = name
         self.client_id = client_id
         self.client_secret = client_secret
         if not redirect_uris:
-            raise ValueError("redirect_uris must provide at least one value to use as canonical: %s" % redirect_uris)
+            raise ValueError(
+                "redirect_uris must provide at least one value to use as canonical: %s" \
+                % redirect_uris
+            )
         self.redirect_uris = redirect_uris
 
     @property

--- a/profiles/clients.py
+++ b/profiles/clients.py
@@ -7,6 +7,8 @@ class Client(object):
         self.name = name
         self.client_id = client_id
         self.client_secret = client_secret
+        if not redirect_uris:
+            raise ValueError("redirect_uris must provide at least one value to use as canonical: %s" % redirect_uris)
         self.redirect_uris = redirect_uris
 
     @property

--- a/profiles/exceptions.py
+++ b/profiles/exceptions.py
@@ -38,7 +38,7 @@ class ClientError(OAuth2Error):
     status_code = 302
 
     def __init__(self, client: Client, description: str = None) -> None:
-        self.uri = client.canonical_redirect_uri()
+        self.uri = client.canonical_redirect_uri
 
         super(ClientError, self).__init__(description)
 

--- a/profiles/exceptions.py
+++ b/profiles/exceptions.py
@@ -38,7 +38,7 @@ class ClientError(OAuth2Error):
     status_code = 302
 
     def __init__(self, client: Client, description: str = None) -> None:
-        self.uri = client.redirect_uri
+        self.uri = client.canonical_redirect_uri()
 
         super(ClientError, self).__init__(description)
 

--- a/test/clients/test_client.py
+++ b/test/clients/test_client.py
@@ -1,39 +1,41 @@
 from hypothesis import given
-from hypothesis.strategies import text
+from hypothesis.strategies import lists, one_of, text
 
 from profiles.clients import Client
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), text(min_size=1))
-def test_it_can_be_printed(name, client_id, client_secret, redirect_uri):
-    client = Client(name, client_id, client_secret, redirect_uri)
+# TODO: aren't these overkill for a Value Object that is little more than a tuple?
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+def test_it_can_be_printed(name, client_id, client_secret, redirect_uris):
+    client = Client(name, client_id, client_secret, redirect_uris)
 
     assert '{!r}'.format(client) == "<Client {name!r}>".format(name=name)
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), text(min_size=1))
-def test_it_has_a_name(name, client_id, client_secret, redirect_uri):
-    client = Client(name, client_id, client_secret, redirect_uri)
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+def test_it_has_a_name(name, client_id, client_secret, redirect_uris):
+    client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.name == name
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), text(min_size=1))
-def test_it_has_a_client_id(name, client_id, client_secret, redirect_uri):
-    client = Client(name, client_id, client_secret, redirect_uri)
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+def test_it_has_a_client_id(name, client_id, client_secret, redirect_uris):
+    client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.client_id == client_id
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), text(min_size=1))
-def test_it_has_a_client_secret(name, client_id, client_secret, redirect_uri):
-    client = Client(name, client_id, client_secret, redirect_uri)
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+def test_it_has_a_client_secret(name, client_id, client_secret, redirect_uris):
+    client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.client_secret == client_secret
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), text(min_size=1))
-def test_it_has_a_redirect_uri(name, client_id, client_secret, redirect_uri):
-    client = Client(name, client_id, client_secret, redirect_uri)
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+def test_it_has_redirect_uris(name, client_id, client_secret, redirect_uris):
+    client = Client(name, client_id, client_secret, redirect_uris)
 
-    assert client.redirect_uri == redirect_uri
+    assert client.redirect_uris == redirect_uris
+

--- a/test/clients/test_client.py
+++ b/test/clients/test_client.py
@@ -1,41 +1,37 @@
-from hypothesis import given
-from hypothesis.strategies import lists, sampled_from, text
-
 from profiles.clients import Client
 
 
-# TODO: aren't these overkill for a Value Object that is little more than a tuple?
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
-def test_it_can_be_printed(name, client_id, client_secret, redirect_uris):
+name = 'journal'
+client_id = 'client_id'
+client_secret = 'client_secret'
+redirect_uris = ['example.com', 'example.org', 'testing.example.org']
+
+
+def test_it_can_be_printed():
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert '{!r}'.format(client) == "<Client {name!r}>".format(name=name)
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
-def test_it_has_a_name(name, client_id, client_secret, redirect_uris):
+def test_it_has_a_name():
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.name == name
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
-def test_it_has_a_client_id(name, client_id, client_secret, redirect_uris):
+def test_it_has_a_client_id():
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.client_id == client_id
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
-def test_it_has_a_client_secret(name, client_id, client_secret, redirect_uris):
+def test_it_has_a_client_secret():
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.client_secret == client_secret
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
-def test_it_has_redirect_uris(name, client_id, client_secret, redirect_uris):
+def test_it_has_redirect_uris():
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.redirect_uris == redirect_uris
-

--- a/test/clients/test_client.py
+++ b/test/clients/test_client.py
@@ -1,39 +1,39 @@
 from hypothesis import given
-from hypothesis.strategies import lists, one_of, text
+from hypothesis.strategies import lists, sampled_from, text
 
 from profiles.clients import Client
 
 
 # TODO: aren't these overkill for a Value Object that is little more than a tuple?
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
 def test_it_can_be_printed(name, client_id, client_secret, redirect_uris):
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert '{!r}'.format(client) == "<Client {name!r}>".format(name=name)
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
 def test_it_has_a_name(name, client_id, client_secret, redirect_uris):
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.name == name
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
 def test_it_has_a_client_id(name, client_id, client_secret, redirect_uris):
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.client_id == client_id
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
 def test_it_has_a_client_secret(name, client_id, client_secret, redirect_uris):
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.client_secret == client_secret
 
 
-@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(one_of(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
+@given(text(min_size=1), text(min_size=1), text(min_size=1), lists(sampled_from(["example.com", "example.org", "testing.example.org"]), min_size=1, max_size=3))
 def test_it_has_redirect_uris(name, client_id, client_secret, redirect_uris):
     client = Client(name, client_id, client_secret, redirect_uris)
 

--- a/test/clients/test_client.py
+++ b/test/clients/test_client.py
@@ -1,3 +1,4 @@
+import pytest
 from profiles.clients import Client
 
 
@@ -36,9 +37,11 @@ def test_it_has_redirect_uris():
 
     assert client.redirect_uris == redirect_uris
 
+
 def test_it_must_have_at_least_one_redirect_uri():
     with pytest.raises(ValueError):
-        client = Client(name, client_id, client_secret, [])
+        Client(name, client_id, client_secret, [])
+
 
 def test_it_has_a_canonical_redirect_uri():
     client = Client(name, client_id, client_secret, redirect_uris)

--- a/test/clients/test_client.py
+++ b/test/clients/test_client.py
@@ -36,6 +36,10 @@ def test_it_has_redirect_uris():
 
     assert client.redirect_uris == redirect_uris
 
+def test_it_must_have_at_least_one_redirect_uri():
+    with pytest.raises(ValueError):
+        client = Client(name, client_id, client_secret, [])
+
 def test_it_has_a_canonical_redirect_uri():
     client = Client(name, client_id, client_secret, redirect_uris)
 

--- a/test/clients/test_client.py
+++ b/test/clients/test_client.py
@@ -35,3 +35,8 @@ def test_it_has_redirect_uris():
     client = Client(name, client_id, client_secret, redirect_uris)
 
     assert client.redirect_uris == redirect_uris
+
+def test_it_has_a_canonical_redirect_uri():
+    client = Client(name, client_id, client_secret, redirect_uris)
+
+    assert client.canonical_redirect_uri == 'example.com'

--- a/test/clients/test_clients.py
+++ b/test/clients/test_clients.py
@@ -8,7 +8,10 @@ from profiles.clients import Client, Clients
 
 @given(lists(text(), max_size=4, min_size=4), lists(text(), max_size=4, min_size=4))
 def test_it_contains_clients(client1_args, client2_args):
-    clients = Clients(Client(*client1_args), Client(*client2_args))
+    clients = Clients(
+        Client('name1', client_id1, 'client_secret1', ['redirect_uri1']),
+        Client('name2', client_id2, 'client_secret2', ['redirect_uri2'])
+    )
 
     assert len(clients) == 2
 
@@ -19,8 +22,8 @@ def test_it_finds_clients(id_base):
     client_id2 = id_base + '2'
     unknown_client_id = id_base + 'unknown'
 
-    client1 = Client('name1', client_id1, 'client_secret1', 'redirect_uri1')
-    client2 = Client('name2', client_id2, 'client_secret2', 'redirect_uri2')
+    client1 = Client('name1', client_id1, 'client_secret1', ['redirect_uri1'])
+    client2 = Client('name2', client_id2, 'client_secret2', ['redirect_uri2'])
     clients = Clients(client1, client2)
 
     assert len(clients) == 2

--- a/test/clients/test_clients.py
+++ b/test/clients/test_clients.py
@@ -1,5 +1,5 @@
 from hypothesis import given
-from hypothesis.strategies import lists, text
+from hypothesis.strategies import text
 
 import pytest
 

--- a/test/clients/test_clients.py
+++ b/test/clients/test_clients.py
@@ -6,11 +6,10 @@ import pytest
 from profiles.clients import Client, Clients
 
 
-@given(lists(text(), max_size=4, min_size=4), lists(text(), max_size=4, min_size=4))
-def test_it_contains_clients(client1_args, client2_args):
+def test_it_contains_clients():
     clients = Clients(
-        Client('name1', client_id1, 'client_secret1', ['redirect_uri1']),
-        Client('name2', client_id2, 'client_secret2', ['redirect_uri2'])
+        Client('name1', 'client_id1', 'client_secret1', ['redirect_uri1']),
+        Client('name2', 'client_id2', 'client_secret2', ['redirect_uri2'])
     )
 
     assert len(clients) == 2

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,7 +63,7 @@ def app(request: FixtureRequest) -> Flask:
         ),
         clients=Clients(
             Client(name='client', client_id='client_id', client_secret='client_secret',
-                   redirect_uri='http://www.example.com/client/redirect'),
+                   redirect_uris=['http://www.example.com/client/redirect']),
         ),
     )
 


### PR DESCRIPTION
Will make both `elifesciences.org` and `elifejournal.org` (for Fastly testing) supported at the same time.

Formula to be updated prior to merge, upon approval.