### PR TITLE
Push from containers new nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,12 +55,11 @@ elifePipeline {
 
         stage 'Approval', {
             elifeGitMoveToBranch commit, 'approved'
-            elifeOnNode(
-                {
-                    image.tag('approved').push()
-                },
-                'elife-libraries--ci'
-            )
+            node('containers-jenkins-plugin') {
+                image = DockerImage.elifesciences(this, "profiles", commit)
+                image.pull()
+                image.tag('approved').push()
+            }
         }
     }
 }


### PR DESCRIPTION
These are throwaway instances so the image may have never been pulled on one.