### PR TITLE
fix db getting into broken state

### DIFF
--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -36,8 +36,12 @@ def test_it_updates_and_returns_204_if_a_profile_is_found(test_client: FlaskClie
     assert profile.name.preferred == 'Given Names Family Name'
 
 
-def test_it_does_not_cause_db_to_get_into_broken_state(test_client: FlaskClient,
-                                                       webhook_payload: str) -> None:
+def test_it_prevents_unique_constraint_error_when_inserting_existing_email_address(
+        test_client: FlaskClient, webhook_payload: str) -> None:
+    """
+    This test was added as a result of this issue:
+    https://github.com/elifesciences/issues/issues/4633
+    """
 
     profile_1 = Profile('a1b2c3d4', Name('Foo Bar'))
     profile_1.add_email_address('1@example.com', restricted=False)

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -36,6 +36,7 @@ def test_it_updates_and_returns_204_if_a_profile_is_found(test_client: FlaskClie
     assert profile.name.preferred == 'Given Names Family Name'
 
 
+# pylint: disable=invalid-name
 def test_it_prevents_unique_constraint_error_when_inserting_existing_email_address(
         test_client: FlaskClient, webhook_payload: str) -> None:
     """
@@ -91,6 +92,7 @@ def test_it_prevents_unique_constraint_error_when_inserting_existing_email_addre
     assert data['orcid'] == '0000-0002-1825-0097'
     assert data['emailAddresses'] == []
     assert data['name']['preferred'] == 'New Name'
+# pylint: enable=invalid-name
 
 
 def test_it_returns_404_if_a_payload_is_invalid(test_client: FlaskClient) -> None:


### PR DESCRIPTION
Relates to https://github.com/elifesciences/issues/issues/4633

Fix for db getting into broken transaction state.

Seems to be an issue with either Flask-SQLAlchemy or SQLAlchemy. Either way, no exception is raised by either framework. The problem becomes apparent when trying to access the database after the database is in a broken state.

I have tried updating all dependencies to the latest version but the problem still persists.

My solution is to add a check to see if an email in an incoming ORCID record tries to update a profile with an email associated with another profile. If the email already exists the error is logged and the email is removed from the list of emails to process/update.