### PR TITLE
bugfix, RequestException.response may be None in some cases.

### DIFF
--- a/profiles/api/webhook.py
+++ b/profiles/api/webhook.py
@@ -47,12 +47,12 @@ def create_blueprint(profiles: Profiles, orcid_config: Dict[str, str],
         try:
             orcid_record = orcid_client.get_record(orcid, access_token)
         except RequestException as exception:
-            if exception.response.status_code == 403 and not access_token == \
-                    orcid_config.get('read_public_access_token'):
-                orcid_tokens.remove(profile.orcid)
+            if exception.response and exception.response.status_code == 403:
+                if not access_token == orcid_config.get('read_public_access_token'):
+                    orcid_tokens.remove(profile.orcid)
 
-                # Let ORCID retry, it will use the public access token
-                raise ServiceUnavailable from exception
+                    # Let ORCID retry, it will use the public access token
+                    raise ServiceUnavailable from exception
 
             raise InternalServerError from exception
 

--- a/profiles/api/webhook.py
+++ b/profiles/api/webhook.py
@@ -47,7 +47,9 @@ def create_blueprint(profiles: Profiles, orcid_config: Dict[str, str],
         try:
             orcid_record = orcid_client.get_record(orcid, access_token)
         except RequestException as exception:
-            if exception.response and exception.response.status_code == 403:
+            # lsh@2023-05-09: exception.response may be None
+            # https://requests.readthedocs.io/en/latest/_modules/requests/exceptions/#RequestException
+            if exception.response is not None and exception.response.status_code == 403:
                 if not access_token == orcid_config.get('read_public_access_token'):
                     orcid_tokens.remove(profile.orcid)
 


### PR DESCRIPTION
Fix for this error:

```json
{
  "name": "profiles.api.errors",
  "message": "'NoneType' object has no attribute 'status_code'",
  "asctime": "2023-04-29 13:15:34,946",
  "levelname": "ERROR",
  "exc_info": {
    "message": "'NoneType' object has no attribute 'status_code'",
    "class": "AttributeError",
    "trace": [
      "  File \"/srv/profiles/venv/lib/python3.8/site-packages/flask/app.py\", line 1823, in full_dispatch_request\n    rv = self.dispatch_request()\n",
      "  File \"/srv/profiles/venv/lib/python3.8/site-packages/flask/app.py\", line 1799, in dispatch_request\n    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)\n",
      "  File \"/srv/profiles/venv/lib/python3.8/site-packages/newrelic/hooks/framework_flask.py\", line 82, in _nr_wrapper_handler_\n    return wrapped(*args, **kwargs)\n",
      "  File \"/srv/profiles/./profiles/api/webhook.py\", line 50, in _update\n    if exception.response.status_code == 403 and not access_token == \\\n"
    ]
  }
}
```