### PR TITLE
orcid, bumps num retries from 3 to 5, increases backoff factor from 0.3 to 0.5.

### DIFF
--- a/profiles/orcid.py
+++ b/profiles/orcid.py
@@ -68,7 +68,7 @@ class OrcidClient(object):
         uri = '{}/{}'.format(self.api_uri, path)
         headers['Authorization'] = 'Bearer ' + access_token
 
-        MAX_RETRIES = 3
+        MAX_RETRIES = 5
 
         # lsh@2023-07-28: handle network errors better.
         # - https://urllib3.readthedocs.io/en/stable/user-guide.html#retrying-requests
@@ -83,8 +83,8 @@ class OrcidClient(object):
             'status_forcelist': [413, 429, 503, # defaults
                                  500, 502, 504],
             # {backoff factor} * (2 ** {number of previous retries})
-            # 0.3 => 0.3, 0.6, 1.2, 2.4, 4.8
-            'backoff_factor': 0.3,
+            # 0.5 => 1.0, 2.0, 4.0, 8.0, 16.0
+            'backoff_factor': 0.5,
         })
         adaptor = requests.adapters.HTTPAdapter(max_retries=max_retries_obj)
         session = requests.Session()


### PR DESCRIPTION


gives us a worse case scenario of five attempts with the last at 16s